### PR TITLE
Use headless contexts in tests

### DIFF
--- a/src/gpu/builders.rs
+++ b/src/gpu/builders.rs
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_render_pass_builder() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let viewport: Viewport = Default::default();
         let desc = AttachmentDescription::default();
         let dep = SubpassDependency {
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_display_builder() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let dsp = DisplayBuilder::new()
             .title("test")
             .size(300, 200)
@@ -419,7 +419,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_graphics_pipeline_layout_builder_missing_vertex_info() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             GraphicsPipelineLayoutBuilder::new("gpl")
                 .build(&mut ctx)
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_graphics_pipeline_builder_missing_fields() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             GraphicsPipelineBuilder::new("gp").build(&mut ctx).unwrap();
         }));
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_compute_pipeline_layout_builder_missing_shader() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             ComputePipelineLayoutBuilder::new().build(&mut ctx).unwrap();
         }));
@@ -454,7 +454,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_compute_pipeline_builder_missing_layout() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             ComputePipelineBuilder::new("cp").build(&mut ctx).unwrap();
         }));
@@ -465,7 +465,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_bind_group_layout_builder() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let shader_info = crate::ShaderInfo {
             shader_type: crate::ShaderType::All,
             variables: &[],
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_bind_group_builder() {
-        let mut ctx = Context::new(&ContextInfo::default()).unwrap();
+        let mut ctx = Context::headless(&ContextInfo::default()).unwrap();
         let shader_info = crate::ShaderInfo {
             shader_type: crate::ShaderType::All,
             variables: &[],

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -2934,7 +2934,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_context() {
-        let ctx = Context::new(&Default::default());
+        let ctx = Context::headless(&Default::default());
         assert!(ctx.is_ok());
         ctx.unwrap().destroy();
     }
@@ -2944,7 +2944,7 @@ mod tests {
     fn test_buffer() {
         let c_buffer_size = 1280;
         let c_test_val = 8 as u8;
-        let mut ctx = Context::new(&Default::default()).unwrap();
+        let mut ctx = Context::headless(&Default::default()).unwrap();
 
         let initial_data = vec![c_test_val as u8; c_buffer_size as usize];
         let buffer_res = ctx.make_buffer(&BufferInfo {
@@ -2983,7 +2983,7 @@ mod tests {
         let c_test_val = 8 as u8;
         let initial_data =
             vec![c_test_val as u8; (c_test_dim[0] * c_test_dim[1] * c_test_dim[2] * 4) as usize];
-        let mut ctx = Context::new(&Default::default()).unwrap();
+        let mut ctx = Context::headless(&Default::default()).unwrap();
         let image_res = ctx.make_image(&ImageInfo {
             debug_name: "Test Image",
             dim: c_test_dim,
@@ -3063,7 +3063,7 @@ mod tests {
     #[serial]
     fn compute_test() {
         // The GPU context that holds all the data.
-        let mut ctx = Context::new(&Default::default()).unwrap();
+        let mut ctx = Context::headless(&Default::default()).unwrap();
 
         // Make the bind group layout. This describes the bindings into a shader.
         let bg_layout = ctx

--- a/src/utils/gpupool.rs
+++ b/src/utils/gpupool.rs
@@ -124,7 +124,7 @@ mod tests {
             _big_data: [u32; 16],
         }
 
-        let mut ctx = Context::new(&Default::default()).unwrap();
+        let mut ctx = Context::headless(&Default::default()).unwrap();
 
         let mut pool = GPUPool::new(
             &mut ctx,

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -72,15 +72,11 @@ impl Timer {
 
 #[cfg(feature = "dashi-tests")]
 fn main() {
-    let device = DeviceSelector::new()
-        .unwrap()
-        .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
-        .unwrap_or_default();
-
+    let device = SelectedDevice::default();
     println!("Using device {}", device);
 
     // The GPU context that holds all the data.
-    let mut ctx = gpu::Context::new(&ContextInfo { device }).unwrap();
+    let mut ctx = gpu::Context::headless(&ContextInfo { device }).unwrap();
 
     const WIDTH: u32 = 1280;
     const HEIGHT: u32 = 1024;


### PR DESCRIPTION
## Summary
- switch hello_triangle example to headless mode and default device
- use `Context::headless` instead of `Context::new` in GPU tests
- update `GPUPool` tests to create headless contexts

## Testing
- `cargo test --quiet` *(fails: rustfmt component install and build require network)*

------
https://chatgpt.com/codex/tasks/task_e_68434e9ade10832aa5570ff4236812bd