### PR TITLE
Remove mut from descriptor set count

### DIFF
--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1801,7 +1801,7 @@ impl Context {
         &mut self,
         info: &BindGroupLayoutInfo,
     ) -> Result<Handle<BindGroupLayout>, GPUError> {
-        let mut max_descriptor_sets: u32 = 2048;
+        let max_descriptor_sets: u32 = 2048;
         let mut bindings = Vec::new();
         for shader_info in info.shaders.iter() {
             for variable in shader_info.variables.iter() {


### PR DESCRIPTION
## Summary
- clean up an unused `mut` in `make_bind_group_layout`

## Testing
- `cargo check`
- `cargo test` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68439da28080832a89cb742e84a02b2f