### PR TITLE
Fix unused variable warning in bind_draw_descriptor_sets

### DIFF
--- a/src/gpu/commands.rs
+++ b/src/gpu/commands.rs
@@ -715,7 +715,7 @@ impl CommandList {
         dyn_bufs: &[Option<DynamicBuffer>; 4],
         bgs: &[Option<Handle<BindGroup>>; 4],
     ) {
-        for (i, bg_opt) in bgs.iter().enumerate() {
+        for (_i, bg_opt) in bgs.iter().enumerate() {
             if let Some(bg) = bg_opt {
                 let bg_data = self.ctx_ref().bind_groups.get_ref(*bg).unwrap();
                 let offsets: Vec<u32> = dyn_bufs


### PR DESCRIPTION
## Summary
- silence unused index warning in descriptor binding loop

## Testing
- `cargo check`
- `cargo test` *(fails: signal 11)*

------
https://chatgpt.com/codex/tasks/task_e_68439da1d79c832a97887698e651cd89