### PR TITLE
Fix unused variable warning

### DIFF
--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1678,7 +1678,7 @@ impl Context {
 
     pub fn destroy_render_pass(&mut self, handle: Handle<RenderPass>) {
         let rp = self.render_passes.get_ref(handle).unwrap();
-        for (id, sb) in &rp.subpasses {
+        for (_id, sb) in &rp.subpasses {
             unsafe { self.device.destroy_framebuffer(sb.fb, None) };
         }
 


### PR DESCRIPTION
## Summary
- avoid unused variable warning in `destroy_render_pass`

## Testing
- `cargo check`
- `cargo test` *(fails: SIGSEGV)*

------
https://chatgpt.com/codex/tasks/task_e_68439da2260c832aa8a6ade5466aea59