### PR TITLE
Remove WindowInfo import

### DIFF
--- a/src/gpu/builders.rs
+++ b/src/gpu/builders.rs
@@ -6,7 +6,7 @@ use crate::{
     ComputePipelineLayout, ComputePipelineLayoutInfo, Display, DisplayInfo, GraphicsPipeline,
     GraphicsPipelineDetails, GraphicsPipelineInfo, GraphicsPipelineLayout,
     GraphicsPipelineLayoutInfo, PipelineShaderInfo, RenderPass, RenderPassInfo, SubpassDependency,
-    SubpassDescription, VertexDescriptionInfo, Viewport, WindowBuffering, WindowInfo,
+    SubpassDescription, VertexDescriptionInfo, Viewport, WindowBuffering,
 };
 use crate::{Context, GPUError};
 


### PR DESCRIPTION
## Summary
- clean up builders module import list

## Testing
- `cargo check`
- `cargo test` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68439d9e5fac832a93130966b8090962