### PR TITLE
Fix ash version entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ debug_offset_alloc = []
 use_16_bit_node_indices = []
 
 [dependencies]
-ash = "0.37.3+1.3.251"
+ash = "0.37.3"
 vk-mem = "0.3.0"
 sdl2 = {version = "0.37.0", features = ["bundled", "static-link", "raw-window-handle"]}
 serde = {version = "1.0.210", features = ["derive"], optional = true}


### PR DESCRIPTION
## Summary
- remove ignored version metadata from ash dependency

## Testing
- `cargo check`
- `cargo test` *(fails: process didn't exit successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68439d9dba78832a93fc1d463ba357c7