### PR TITLE
Remove unused attachments field from SubpassContainer

### DIFF
--- a/src/gpu/commands.rs
+++ b/src/gpu/commands.rs
@@ -917,7 +917,6 @@ impl CommandList {
             rp.subpasses.insert(
                 key,
                 SubpassContainer {
-                    attachments: info.attachments.to_vec(),
                     fb,
                     clear_values: clear_vals,
                 },

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -397,7 +397,6 @@ pub struct ImageView {
 
 #[derive(Clone, Default)]
 pub(super) struct SubpassContainer {
-    pub(super) attachments: Vec<Attachment>,
     pub(super) fb: vk::Framebuffer,
     pub(super) clear_values: Vec<vk::ClearValue>,
 }


### PR DESCRIPTION
## Summary
- simplify `SubpassContainer` by dropping unused `attachments`
- adjust framebuffer caching logic

## Testing
- `cargo check`
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6843a91b1784832a9097b994e01dc253