### PR TITLE
Fix unused variable warnings

### DIFF
--- a/src/gpu/builders.rs
+++ b/src/gpu/builders.rs
@@ -471,11 +471,11 @@ mod tests {
             shader_type: crate::ShaderType::All,
             variables: &[],
         };
-        let bgl = BindGroupLayoutBuilder::new("bgl")
+        let _bgl = BindGroupLayoutBuilder::new("bgl")
             .shader(shader_info)
             .build(&mut ctx)
             .unwrap();
-        //        ctx.destroy_bind_group_layout(bgl);
+        //        ctx.destroy_bind_group_layout(_bgl);
         ctx.destroy();
     }
 
@@ -491,11 +491,11 @@ mod tests {
             .shader(shader_info)
             .build(&mut ctx)
             .unwrap();
-        let bg = BindGroupBuilder::new("bg")
+        let _bg = BindGroupBuilder::new("bg")
             .layout(bgl)
             .build(&mut ctx)
             .unwrap();
-        //    ctx.destroy_bind_group(bg);
+        //    ctx.destroy_bind_group(_bg);
         ctx.destroy();
     }
 
@@ -586,7 +586,7 @@ mod tests {
             "#,
             vert
         );
-        let layout = GraphicsPipelineLayoutBuilder::new("gpl")
+        let _layout = GraphicsPipelineLayoutBuilder::new("gpl")
             .vertex_info(vert_info)
             .bind_group_layout(0, bgl)
             .shader(PipelineShaderInfo {

--- a/src/gpu/framed_cmd_list.rs
+++ b/src/gpu/framed_cmd_list.rs
@@ -165,7 +165,7 @@ mod tests {
         let mut fcl = FramedCommandList::new(&mut ctx, "basic", 3);
 
         // do 10 cycles of append + submit
-        for i in 0..10 {
+        for _ in 0..10 {
             fcl.append(|cmd| {
                 // we can even record a no-op dispatch or whatever
                 // here we just begin/end an empty command list

--- a/src/utils/offset_alloc.rs
+++ b/src/utils/offset_alloc.rs
@@ -530,7 +530,7 @@ mod tests {
 
     #[test]
     fn test_allocation_no_space() {
-        let allocator = Allocator::new(1024, 2);
+        let _allocator = Allocator::new(1024, 2);
         let allocation = Allocation::NO_SPACE;
         assert_eq!(allocation, 0xffffffff);
     }


### PR DESCRIPTION
## Summary
- silence unused variable warnings in GPU builders tests
- clean up unused loop variable in FramedCommandList tests
- mark unused `allocator` in offset allocator test

## Testing
- `RUSTFLAGS='-D warnings' cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843b247e9f0832a801ea4417bccb993