### PR TITLE
Add DirectX 12 backend feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "serde",
  "serial_test",
  "vk-mem",
+ "windows",
  "winit",
 ]
 
@@ -1694,6 +1695,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,23 +5,26 @@ edition = "2021"
 license = "MIT"
 
 [features]
-default = ["dashi-winit"]
+default = ["dashi-winit", "dashi-vulkan"]
 dashi-winit = ["dep:winit"]
 dashi-sdl2 = ["dep:sdl2"]
 dashi-minifb = ["dep:minifb"]
 dashi-serde = ["dep:serde"]
 debug_offset_alloc = []
 use_16_bit_node_indices = []
+dashi-vulkan = ["dep:ash", "dep:vk-mem", "dep:ash-window"]
+dashi-dx12 = ["dep:windows"]
 
 [dependencies]
-ash = "0.37.3"
-vk-mem = "0.3.0"
+ash = { version = "0.37.3", optional = true }
+vk-mem = { version = "0.3.0", optional = true }
 sdl2 = {version = "0.35.2", features = ["bundled", "static-link", "raw-window-handle"], optional = true}
-ash-window = "0.11"
+ash-window = { version = "0.11", optional = true }
 minifb = { version = "0.24", optional = true }
 winit = { version = "0.26", optional = true }
 raw-window-handle = "0.4"
 serde = {version = "1.0.210", features = ["derive"], optional = true}
+windows = { version = "0.52.0", optional = true, features = ["Win32_Graphics_Direct3D12"] }
 
 [patch.crates-io]
 orbclient = { path = "orbclient_stub" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,7 @@ compile_error!(
     "window backends are mutually exclusive; enable only one of `dashi-sdl2`, `dashi-minifb`, or `dashi-winit`"
 );
 
+#[cfg(all(feature = "dashi-vulkan", feature = "dashi-dx12"))]
+compile_error!("GPU backends are mutually exclusive; enable only one of `dashi-vulkan` or `dashi-dx12`");
+
 pub use gpu::*;


### PR DESCRIPTION
## Summary
- add `dashi-dx12` feature and make GPU backends optional
- use `windows` crate for DirectX 12 bindings
- check that `dashi-vulkan` and `dashi-dx12` cannot both be enabled

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68595e951a0c832a9d41fdf87690330f