### PR TITLE
Add GPU timing utilities

### DIFF
--- a/examples/gpu_timing.rs
+++ b/examples/gpu_timing.rs
@@ -1,0 +1,22 @@
+use dashi::*;
+
+fn main() {
+    let mut ctx = gpu::Context::headless(&ContextInfo::default()).unwrap();
+    ctx.init_gpu_timers(1).unwrap();
+
+    let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+    ctx.gpu_timer_begin(&mut list, 0);
+    // no-op workload
+    ctx.gpu_timer_end(&mut list, 0);
+
+    let fence = ctx.submit(&mut list, &Default::default()).unwrap();
+    ctx.wait(fence).unwrap();
+
+    if let Some(ms) = ctx.get_elapsed_gpu_time_ms(0) {
+        println!("GPU elapsed time: {:.3} ms", ms);
+    } else {
+        println!("Unable to query GPU time");
+    }
+
+    ctx.destroy();
+}

--- a/src/gpu/timing.rs
+++ b/src/gpu/timing.rs
@@ -1,0 +1,46 @@
+use ash::vk;
+use crate::GPUError;
+
+pub struct GpuTimer {
+    pub(super) pool: vk::QueryPool,
+}
+
+impl GpuTimer {
+    pub(super) fn new(device: &ash::Device) -> Result<Self, GPUError> {
+        let info = vk::QueryPoolCreateInfo::builder()
+            .query_count(2)
+            .query_type(vk::QueryType::TIMESTAMP)
+            .build();
+        let pool = unsafe { device.create_query_pool(&info, None)? };
+        Ok(Self { pool })
+    }
+
+    pub(super) unsafe fn destroy(&self, device: &ash::Device) {
+        device.destroy_query_pool(self.pool, None);
+    }
+
+    pub(super) unsafe fn begin(&self, device: &ash::Device, cmd: vk::CommandBuffer) {
+        device.cmd_reset_query_pool(cmd, self.pool, 0, 2);
+        device.cmd_write_timestamp(cmd, vk::PipelineStageFlags::TOP_OF_PIPE, self.pool, 0);
+    }
+
+    pub(super) unsafe fn end(&self, device: &ash::Device, cmd: vk::CommandBuffer) {
+        device.cmd_write_timestamp(cmd, vk::PipelineStageFlags::BOTTOM_OF_PIPE, self.pool, 1);
+    }
+
+    pub(super) fn resolve(&self, device: &ash::Device, period: f32) -> Result<f32, GPUError> {
+        let mut data = [0u64; 2];
+        unsafe {
+            device.get_query_pool_results(
+                self.pool,
+                0,
+                2,
+                &mut data,
+                vk::QueryResultFlags::TYPE_64 | vk::QueryResultFlags::WAIT,
+            )?;
+        }
+        let diff = data[1].saturating_sub(data[0]);
+        Ok(diff as f32 * period / 1_000_000.0)
+    }
+}
+

--- a/tests/gpu_timer.rs
+++ b/tests/gpu_timer.rs
@@ -1,0 +1,22 @@
+use dashi::*;
+
+#[test]
+fn gpu_timer() {
+    let mut ctx = gpu::Context::headless(&ContextInfo::default()).unwrap();
+    ctx.init_gpu_timers(1).unwrap();
+
+    let mut list = ctx
+        .begin_command_list(&CommandListInfo { debug_name: "timer", ..Default::default() })
+        .unwrap();
+    ctx.gpu_timer_begin(&mut list, 0);
+    // intentionally no operations to measure minimal overhead
+    ctx.gpu_timer_end(&mut list, 0);
+    let fence = ctx.submit(&mut list, &Default::default()).unwrap();
+    ctx.wait(fence).unwrap();
+
+    let elapsed = ctx.get_elapsed_gpu_time_ms(0).unwrap();
+    assert!(elapsed >= 0.0);
+
+    ctx.destroy_cmd_list(list);
+    ctx.destroy();
+}


### PR DESCRIPTION
## Summary
- add a `GpuTimer` abstraction for Vulkan timestamp queries
- manage per-frame timers in `Context`
- expose methods for measuring GPU time
- allocate timers for displays
- show usage in a new `gpu_timing` example
- add an automated test for GPU timing

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685958458848832a90b18368b8304b11