### PR TITLE
Add UVec4 variant

### DIFF
--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -2513,6 +2513,7 @@ impl Context {
                         ShaderPrimitiveType::Vec3 => vk::Format::R32G32B32_SFLOAT,
                         ShaderPrimitiveType::Vec2 => vk::Format::R32G32_SFLOAT,
                         ShaderPrimitiveType::IVec4 => vk::Format::R32G32B32A32_SINT,
+                        ShaderPrimitiveType::UVec4 => vk::Format::R32G32B32A32_UINT,
                     })
                     .offset(entry.offset as u32)
                     .build()

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -672,6 +672,7 @@ pub enum ShaderPrimitiveType {
     Vec3,
     Vec4,
     IVec4,
+    UVec4,
 }
 
 #[derive(Hash, Debug, Clone)]


### PR DESCRIPTION
## Summary
- add `UVec4` to `ShaderPrimitiveType`
- support Vulkan `R32G32B32A32_UINT` for the new type

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685a223ff7a8832aa4fe8651ec170f78