### PR TITLE
Implement OpenXR display helpers

### DIFF
--- a/src/gpu/builders.rs
+++ b/src/gpu/builders.rs
@@ -9,6 +9,8 @@ use crate::{
     SubpassDescription, VertexDescriptionInfo, Viewport, WindowBuffering,
 };
 use crate::{Context, GPUError};
+#[cfg(feature = "dashi-openxr")]
+use crate::XrDisplayInfo;
 
 /// Builds a RenderPass via the builder pattern.
 pub struct RenderPassBuilder<'a> {
@@ -100,6 +102,12 @@ impl DisplayBuilder {
     /// Finalize and create the Display.
     pub fn build(self, ctx: &mut Context) -> Result<Display, GPUError> {
         ctx.make_display(&self.info)
+    }
+
+    /// Create an OpenXR display when the `dashi-openxr` feature is enabled.
+    #[cfg(feature = "dashi-openxr")]
+    pub fn build_xr(&self, ctx: &mut Context) -> Result<Display, GPUError> {
+        ctx.make_xr_display(&XrDisplayInfo::default())
     }
 }
 

--- a/src/gpu/openxr_window.rs
+++ b/src/gpu/openxr_window.rs
@@ -16,6 +16,8 @@ pub fn create_xr_session(
     (
         xr::Instance,
         xr::Session<xr::Vulkan>,
+        xr::FrameWaiter,
+        xr::FrameStream<xr::Vulkan>,
         xr::Swapchain<xr::Vulkan>,
         Vec<xr::vulkan::SwapchainImage>,
         Vec<xr::ViewConfigurationView>,
@@ -48,7 +50,7 @@ pub fn create_xr_session(
 
     let system = instance.system(xr::FormFactor::HEAD_MOUNTED_DISPLAY)?;
 
-    let (session, _, _) = instance.create_session::<xr::Vulkan>(
+    let (session, waiter, stream) = instance.create_session::<xr::Vulkan>(
         system,
         &xr::vulkan::SessionCreateInfo {
             instance: vk_instance.handle().as_raw() as _,
@@ -80,5 +82,5 @@ pub fn create_xr_session(
     })?;
     let images = swapchain.enumerate_images()?;
 
-    Ok((instance, session, swapchain, images, views))
+    Ok((instance, session, waiter, stream, swapchain, images, views))
 }

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -861,3 +861,11 @@ impl Default for DisplayInfo {
         }
     }
 }
+
+/// Information used when creating an OpenXR display.
+///
+/// Currently no configuration options are required but the
+/// struct exists for future expansion and a consistent API.
+#[cfg(feature = "dashi-openxr")]
+#[derive(Default)]
+pub struct XrDisplayInfo;


### PR DESCRIPTION
## Summary
- add `XrDisplayInfo` structure
- keep `FrameWaiter` and `FrameStream` in `Display`
- create XR display with session helpers
- expose XR frame acquisition/present functions
- allow `DisplayBuilder` to construct XR displays

## Testing
- `cargo check`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688535096c7c832ab182a5d51e05f178