### PR TITLE
Fix render pass cleanup

### DIFF
--- a/src/gpu/commands.rs
+++ b/src/gpu/commands.rs
@@ -792,6 +792,8 @@ impl CommandList {
                 unsafe { (*self.ctx).device.cmd_end_render_pass(self.cmd_buf) };
                 self.last_op_stage = vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT;
                 self.last_op_access = vk::AccessFlags::COLOR_ATTACHMENT_WRITE;
+                self.curr_rp = None;
+                self.curr_pipeline = None;
                 Ok(())
             }
             None => return Err(GPUError::LibraryError()),


### PR DESCRIPTION
## Summary
- update `end_drawing` to clear current render pass and pipeline after ending the Vulkan render pass

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688a6d7ad8e4832abf1543623a22d8b3