### PR TITLE
Add dynamic pipeline state configuration

### DIFF
--- a/src/gpu/builders.rs
+++ b/src/gpu/builders.rs
@@ -6,7 +6,7 @@ use crate::{
     ComputePipelineLayout, ComputePipelineLayoutInfo, Display, DisplayInfo, GraphicsPipeline,
     GraphicsPipelineDetails, GraphicsPipelineInfo, GraphicsPipelineLayout,
     GraphicsPipelineLayoutInfo, PipelineShaderInfo, RenderPass, RenderPassInfo, SubpassDependency,
-    SubpassDescription, VertexDescriptionInfo, Viewport, WindowBuffering,
+    SubpassDescription, VertexDescriptionInfo, Viewport, WindowBuffering, DynamicState,
 };
 use crate::{Context, GPUError};
 #[cfg(feature = "dashi-openxr")]
@@ -161,6 +161,12 @@ impl<'a> GraphicsPipelineLayoutBuilder<'a> {
     /// Configure blend, culling, topology, etc.
     pub fn details(mut self, details: GraphicsPipelineDetails) -> Self {
         self.details = details;
+        self
+    }
+
+    /// Specify which pipeline states will be set dynamically.
+    pub fn dynamic_states(mut self, states: Vec<DynamicState>) -> Self {
+        self.details.dynamic_states = states;
         self
     }
 

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -581,6 +581,13 @@ pub enum VertexOrdering {
     Clockwise,
 }
 
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "dashi-serde", derive(Serialize, Deserialize))]
+pub enum DynamicState {
+    Viewport,
+    Scissor,
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 #[cfg_attr(feature = "dashi-serde", derive(Serialize, Deserialize))]
 pub struct DepthInfo {
@@ -644,6 +651,8 @@ pub struct GraphicsPipelineDetails {
     pub culling: CullMode,
     pub front_face: VertexOrdering,
     pub depth_test: Option<DepthInfo>,
+    /// Pipeline states that will be configured dynamically at draw time.
+    pub dynamic_states: Vec<DynamicState>,
 }
 
 impl Default for GraphicsPipelineDetails {
@@ -654,6 +663,7 @@ impl Default for GraphicsPipelineDetails {
             front_face: VertexOrdering::Clockwise,
             depth_test: None,
             color_blend_states: vec![Default::default()],
+            dynamic_states: Vec::new(),
             subpass: 0,
         }
     }


### PR DESCRIPTION
## Summary
- add a `DynamicState` enum for graphics pipelines
- track dynamic states inside `GraphicsPipelineDetails`
- allow specifying dynamic states via `GraphicsPipelineLayoutBuilder`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688bd5cf54c4832a94fd3418ea59dae0