### PR TITLE
Add pipeline switch binding to CommandList

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ cargo run --no-default-features --features dashi-openxr --example openxr_simple_
 Creating an image with `mip_levels` greater than 1 will automatically generate
 the full mip chain after the initial data upload.
 
+Switching graphics pipelines without ending the render pass:
+
+```rust
+list.begin_drawing(&DrawBegin { pipeline: first, viewport, attachments })?;
+list.append(Command::Draw(my_draw));
+list.bind_pipeline(second)?; // change pipelines mid-pass
+list.append(Command::Draw(other_draw));
+list.end_drawing()?;
+```
+
 ### Window Backends
 
 Dashi ships with multiple window backends. The default `dashi-winit` feature

--- a/src/gpu/commands.rs
+++ b/src/gpu/commands.rs
@@ -252,6 +252,7 @@ pub enum Command {
     DrawIndexedDynamic(DrawIndexedDynamic),
     DrawIndexedIndirect(DrawIndexedIndirect),
     DrawIndirect(DrawIndirect),
+    BindPipeline(Handle<GraphicsPipeline>),
     Blit(ImageBlit),
     ImageBarrier(ImageBarrier),
     Dispatch(Dispatch),
@@ -275,6 +276,7 @@ impl CommandList {
             Command::DrawIndexedDynamic(d) => self.draw_indexed_dynamic(d),
             Command::DrawIndexedIndirect(d) => self.draw_indexed_indirect(d),
             Command::DrawIndirect(d) => self.draw_indirect(d),
+            Command::BindPipeline(p) => self.cmd_bind_pipeline(p),
         }
         self.dirty = true;
     }
@@ -760,30 +762,38 @@ impl CommandList {
         }
     }
 
-    pub fn begin_drawing(&mut self, info: &DrawBegin) -> Result<(), GPUError> {
-        let pipeline = info.pipeline;
-        if let Some(gfx) = self.curr_pipeline {
-            if pipeline == gfx {
-                return Ok(());
-            }
-        }
-
+    fn cmd_bind_pipeline(&mut self, pipeline: Handle<GraphicsPipeline>) {
         unsafe {
-            self.curr_pipeline = Some(pipeline);
-            let gfx = (*self.ctx).gfx_pipelines.get_ref(pipeline).unwrap();
-            self.begin_render_pass(&RenderPassBegin {
-                render_pass: gfx.render_pass,
-                viewport: info.viewport,
-                attachments: info.attachments,
-            })?;
-            (*self.ctx).device.cmd_bind_pipeline(
+            let gfx = self.ctx_ref().gfx_pipelines.get_ref(pipeline).unwrap();
+            self.ctx_ref().device.cmd_bind_pipeline(
                 self.cmd_buf,
                 vk::PipelineBindPoint::GRAPHICS,
                 gfx.raw,
             );
         }
+    }
 
-        return Ok(());
+    pub fn bind_pipeline(&mut self, pipeline: Handle<GraphicsPipeline>) -> Result<(), GPUError> {
+        if self.curr_rp.is_none() {
+            return Err(GPUError::LibraryError());
+        }
+        if self.curr_pipeline == Some(pipeline) {
+            return Ok(());
+        }
+        self.curr_pipeline = Some(pipeline);
+        self.cmd_bind_pipeline(pipeline);
+        Ok(())
+    }
+
+    pub fn begin_drawing(&mut self, info: &DrawBegin) -> Result<(), GPUError> {
+        let pipeline = info.pipeline;
+        let gfx = self.ctx_ref().gfx_pipelines.get_ref(pipeline).unwrap();
+        self.begin_render_pass(&RenderPassBegin {
+            render_pass: gfx.render_pass,
+            viewport: info.viewport,
+            attachments: info.attachments,
+        })?;
+        self.bind_pipeline(pipeline)
     }
 
     pub fn end_drawing(&mut self) -> Result<(), GPUError> {

--- a/tests/pipeline_switch.rs
+++ b/tests/pipeline_switch.rs
@@ -1,0 +1,138 @@
+use dashi::*;
+
+#[test]
+fn pipeline_switch() {
+    const WIDTH: u32 = 64;
+    const HEIGHT: u32 = 64;
+
+    let mut ctx = Context::headless(&Default::default()).unwrap();
+
+    let img = ctx
+        .make_image(&ImageInfo {
+            debug_name: "fb",
+            dim: [WIDTH, HEIGHT, 1],
+            format: Format::RGBA8,
+            mip_levels: 1,
+            initial_data: None,
+            ..Default::default()
+        })
+        .unwrap();
+
+    let view = ctx
+        .make_image_view(&ImageViewInfo { img, ..Default::default() })
+        .unwrap();
+
+    let rp = ctx
+        .make_render_pass(&RenderPassInfo {
+            debug_name: "rp",
+            viewport: Viewport {
+                area: FRect2D { w: WIDTH as f32, h: HEIGHT as f32, ..Default::default() },
+                scissor: Rect2D { w: WIDTH, h: HEIGHT, ..Default::default() },
+                ..Default::default()
+            },
+            subpasses: &[SubpassDescription {
+                color_attachments: &[AttachmentDescription::default()],
+                depth_stencil_attachment: None,
+                subpass_dependencies: &[],
+            }],
+        })
+        .unwrap();
+
+    let vert = inline_spirv::inline_spirv!(r"#version 450
+        vec2 positions[3] = vec2[3](vec2(-0.5,-0.5), vec2(0.5,-0.5), vec2(0.0,0.5));
+        void main() {
+            gl_Position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+        }
+    ", vert);
+
+    let frag_red = inline_spirv::inline_spirv!(r"#version 450
+        layout(location=0) out vec4 color;
+        void main() { color = vec4(1.0,0.0,0.0,1.0); }
+    ", frag);
+
+    let frag_green = inline_spirv::inline_spirv!(r"#version 450
+        layout(location=0) out vec4 color;
+        void main() { color = vec4(0.0,1.0,0.0,1.0); }
+    ", frag);
+
+    let layout_red = ctx
+        .make_graphics_pipeline_layout(&GraphicsPipelineLayoutInfo {
+            debug_name: "layout_red",
+            vertex_info: VertexDescriptionInfo { entries: &[], stride: 0, rate: VertexRate::Vertex },
+            bg_layouts: [None, None, None, None],
+            shaders: &[
+                PipelineShaderInfo { stage: ShaderType::Vertex, spirv: vert, specialization: &[] },
+                PipelineShaderInfo { stage: ShaderType::Fragment, spirv: frag_red, specialization: &[] },
+            ],
+            details: Default::default(),
+        })
+        .unwrap();
+
+    let layout_green = ctx
+        .make_graphics_pipeline_layout(&GraphicsPipelineLayoutInfo {
+            debug_name: "layout_green",
+            vertex_info: VertexDescriptionInfo { entries: &[], stride: 0, rate: VertexRate::Vertex },
+            bg_layouts: [None, None, None, None],
+            shaders: &[
+                PipelineShaderInfo { stage: ShaderType::Vertex, spirv: vert, specialization: &[] },
+                PipelineShaderInfo { stage: ShaderType::Fragment, spirv: frag_green, specialization: &[] },
+            ],
+            details: Default::default(),
+        })
+        .unwrap();
+
+    let pipe_red = ctx
+        .make_graphics_pipeline(&GraphicsPipelineInfo {
+            debug_name: "pipe_red",
+            layout: layout_red,
+            render_pass: rp,
+            ..Default::default()
+        })
+        .unwrap();
+
+    let pipe_green = ctx
+        .make_graphics_pipeline(&GraphicsPipelineInfo {
+            debug_name: "pipe_green",
+            layout: layout_green,
+            render_pass: rp,
+            ..Default::default()
+        })
+        .unwrap();
+
+    let vb = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: "vb",
+            byte_size: 4,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::VERTEX,
+            initial_data: Some(&[0u8; 4]),
+        })
+        .unwrap();
+
+    let mut list = ctx
+        .begin_command_list(&CommandListInfo { debug_name: "draw", ..Default::default() })
+        .unwrap();
+
+    list.begin_drawing(&DrawBegin {
+        viewport: Viewport {
+            area: FRect2D { w: WIDTH as f32, h: HEIGHT as f32, ..Default::default() },
+            scissor: Rect2D { w: WIDTH, h: HEIGHT, ..Default::default() },
+            ..Default::default()
+        },
+        pipeline: pipe_red,
+        attachments: &[Attachment { img: view, clear: ClearValue::Color([0.0,0.0,0.0,1.0]) }],
+    }).unwrap();
+
+    list.append(Command::Draw(Draw { vertices: vb, count: 3, ..Default::default() }));
+
+    list.bind_pipeline(pipe_green).unwrap();
+    list.append(Command::Draw(Draw { vertices: vb, count: 3, ..Default::default() }));
+
+    list.end_drawing().unwrap();
+
+    let fence = ctx.submit(&mut list, &Default::default()).unwrap();
+    ctx.wait(fence).unwrap();
+
+    ctx.destroy_cmd_list(list);
+    ctx.destroy();
+}


### PR DESCRIPTION
## Summary
- allow binding a new pipeline mid-render pass
- expose `bind_pipeline` and add related command variant
- test pipeline switching during a render pass
- document pipeline switching in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688c06d2a4b0832a8c586ca4aa6cec1f