### PR TITLE
Limit Vulkan validation layers to standard layer

### DIFF
--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -37,10 +37,9 @@ pub mod winit_window;
 pub mod openxr_window;
 
 /// Names of debugging layers that should be enabled when validation is requested.
-pub const DEBUG_LAYER_NAMES: [*const c_char; 3] = [
+/// Only includes the standard Vulkan validation layer to avoid enabling any extra layers.
+pub const DEBUG_LAYER_NAMES: [*const c_char; 1] = [
     b"VK_LAYER_KHRONOS_validation\0".as_ptr() as *const c_char,
-    b"VK_LAYER_LUNARG_monitor\0".as_ptr() as *const c_char,
-    b"VK_LAYER_LUNARG_api_dump\0".as_ptr() as *const c_char,
 ];
 
 unsafe extern "system" fn vulkan_debug_callback(


### PR DESCRIPTION
## Summary
- Restrict debug layer list to only `VK_LAYER_KHRONOS_validation`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e4c96a824832a8cbdc5c908221b1e