### PR TITLE
Document GPU timer usage requirements

### DIFF
--- a/examples/gpu_timing.rs
+++ b/examples/gpu_timing.rs
@@ -2,14 +2,17 @@ use dashi::*;
 
 fn main() {
     let mut ctx = gpu::Context::headless(&ContextInfo::default()).unwrap();
+    // GPU timers must be initialized before use.
     ctx.init_gpu_timers(1).unwrap();
 
     let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+    // Begin and end must bracket commands on the same list.
     ctx.gpu_timer_begin(&mut list, 0);
     // no-op workload
     ctx.gpu_timer_end(&mut list, 0);
 
     let fence = ctx.submit(&mut list, &Default::default()).unwrap();
+    // Timing results are valid only after submission and waiting.
     ctx.wait(fence).unwrap();
 
     if let Some(ms) = ctx.get_elapsed_gpu_time_ms(0) {

--- a/tests/gpu_timer.rs
+++ b/tests/gpu_timer.rs
@@ -12,15 +12,18 @@ fn gpu_timer() {
             return;
         }
     };
+    // GPU timers must be initialized before use.
     ctx.init_gpu_timers(1).unwrap();
 
     let mut list = ctx
         .begin_command_list(&CommandListInfo { debug_name: "timer", ..Default::default() })
         .unwrap();
+    // Begin and end must bracket commands on the same list.
     ctx.gpu_timer_begin(&mut list, 0);
     // intentionally no operations to measure minimal overhead
     ctx.gpu_timer_end(&mut list, 0);
     let fence = ctx.submit(&mut list, &Default::default()).unwrap();
+    // Timing results are valid only after submission and waiting.
     ctx.wait(fence).unwrap();
 
     let elapsed = ctx.get_elapsed_gpu_time_ms(0).unwrap();


### PR DESCRIPTION
## Summary
- explain GPU timer initialization and usage requirements
- note that begin/end must bracket commands on the same list
- clarify when elapsed GPU time can be queried

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a92081bbc4832a9c8d4eeedd6b2b03