### PR TITLE
Add bind table support and separate bindless resources

### DIFF
--- a/src/gpu/builders.rs
+++ b/src/gpu/builders.rs
@@ -305,7 +305,6 @@ impl ComputePipelineBuilder {
 pub struct BindGroupLayoutBuilder<'a> {
     debug_name: &'a str,
     shaders: Vec<crate::ShaderInfo<'a>>,
-    bindless: bool,
 }
 
 impl<'a> BindGroupLayoutBuilder<'a> {
@@ -314,7 +313,6 @@ impl<'a> BindGroupLayoutBuilder<'a> {
         Self {
             debug_name,
             shaders: Vec::new(),
-            bindless: false,
         }
     }
 
@@ -324,23 +322,13 @@ impl<'a> BindGroupLayoutBuilder<'a> {
         self
     }
 
-    /// When true, creates a bindless descriptor layout.
-    pub fn bindless(mut self, flag: bool) -> Self {
-        self.bindless = flag;
-        self
-    }
-
     /// Finalize and create the BindGroupLayout.
     pub fn build(self, ctx: &mut Context) -> Result<Handle<BindGroupLayout>, GPUError> {
         let info = crate::BindGroupLayoutInfo {
             debug_name: self.debug_name,
             shaders: &self.shaders,
         };
-        if self.bindless {
-            ctx.make_bindless_bind_group_layout(&info)
-        } else {
-            ctx.make_bind_group_layout(&info)
-        }
+        ctx.make_bind_group_layout(&info)
     }
 }
 

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -1,8 +1,8 @@
 use super::{
-    BindGroupLayout, Buffer, ComputePipelineLayout, DynamicAllocator, GraphicsPipelineLayout,
-    Image, ImageView, RenderPass, Sampler, SelectedDevice,
+    BindGroupLayout, BindTableLayout, Buffer, ComputePipelineLayout, DynamicAllocator,
+    GraphicsPipelineLayout, Image, ImageView, RenderPass, Sampler, SelectedDevice,
 };
-use crate::{utils::Handle, BindGroup, Semaphore};
+use crate::{utils::Handle, BindGroup, BindTable, Semaphore};
 use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "dashi-serde")]
@@ -538,6 +538,11 @@ pub struct BindGroupUpdateInfo<'a> {
     pub bindings: &'a [IndexedBindingInfo<'a>],
 }
 
+pub struct BindTableUpdateInfo<'a> {
+    pub table: Handle<BindTable>,
+    pub bindings: &'a [IndexedBindingInfo<'a>],
+}
+
 pub struct IndexedBindGroupInfo<'a> {
     pub debug_name: &'a str,
     pub layout: Handle<BindGroupLayout>,
@@ -563,14 +568,25 @@ pub struct BindGroupInfo<'a> {
     pub set: u32,
 }
 
-pub struct BindlessBindGroupInfo<'a> {
+pub struct BindTableInfo<'a> {
     pub debug_name: &'a str,
-    pub layout: Handle<BindGroupLayout>,
-    pub bindings: &'a [BindingInfo<'a>],
+    pub layout: Handle<BindTableLayout>,
+    pub bindings: &'a [IndexedBindingInfo<'a>],
     pub set: u32,
 }
 
 impl<'a> Default for BindGroupInfo<'a> {
+    fn default() -> Self {
+        Self {
+            layout: Default::default(),
+            bindings: &[],
+            set: 0,
+            debug_name: "",
+        }
+    }
+}
+
+impl<'a> Default for BindTableInfo<'a> {
     fn default() -> Self {
         Self {
             layout: Default::default(),


### PR DESCRIPTION
## Summary
- Introduce `BindTableLayout` and `BindTable` types to manage bindless descriptors
- Add bind table pools and creation/update routines in `Context`
- Clean up bind table layouts during context destruction

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab835dbe78832a9cf0402d4bb7b221