### PR TITLE
Add BindTable example and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ list.append(Command::Draw(other_draw));
 list.end_drawing()?;
 ```
 
+### Resource Binding
+
+Dashi supports both the classic `BindGroup` pattern and a bindless `BindTable` API for descriptor indexing. The [`hello_triangle`](examples/hello_triangle.rs) example demonstrates `BindGroup` usage, while [`bindless_triangle`](examples/bindless_triangle.rs) shows how to build and bind resources with `BindTable`.
+
 ### Window Backends
 
 Dashi ships with multiple window backends. The default `dashi-winit` feature

--- a/examples/bindless_triangle.rs
+++ b/examples/bindless_triangle.rs
@@ -1,10 +1,9 @@
 use dashi::builders::{BindTableBuilder, BindTableLayoutBuilder};
 use dashi::*;
 
-#[cfg(feature = "dashi-tests")]
-fn main() {
+fn main() -> Result<(), GPUError> {
     // Create a headless context.
-    let mut ctx = gpu::Context::headless(&ContextInfo::default()).unwrap();
+    let mut ctx = gpu::Context::headless(&ContextInfo::default())?;
 
     // Describe a single dynamic uniform buffer at binding 0.
     let shader_info = ShaderInfo {
@@ -16,14 +15,14 @@ fn main() {
         }],
     };
 
-    // Build layout and table, binding a dynamic allocator.
+    // Build the layout and table.
     let layout = BindTableLayoutBuilder::new("bindless_layout")
         .shader(shader_info)
-        .build(&mut ctx)
-        .unwrap();
+        .build(&mut ctx)?;
 
-    let allocator = ctx.make_dynamic_allocator(&Default::default()).unwrap();
-    let _table = BindTableBuilder::new("bindless_table")
+    // Allocate a dynamic buffer and bind it.
+    let allocator = ctx.make_dynamic_allocator(&Default::default())?;
+    let table = BindTableBuilder::new("bindless_table")
         .layout(layout)
         .binding(
             0,
@@ -32,9 +31,8 @@ fn main() {
                 resource: ShaderResource::Dynamic(&allocator),
             }],
         )
-        .build(&mut ctx)
-        .unwrap();
-}
+        .build(&mut ctx)?;
 
-#[cfg(not(feature = "dashi-tests"))]
-fn main() {}
+    println!("Created bind table: {:?}", table);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add bindless_triangle example demonstrating BindTableLayoutBuilder and BindTableBuilder
- update hello_bindless test to use BindTable APIs
- document BindGroup vs bindless BindTable in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abb81e64c4832a835606264f932487