### PR TITLE
Add compute and transfer queue support

### DIFF
--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -25,6 +25,14 @@ pub enum BufferUsage {
     STORAGE,
 }
 
+#[derive(Hash, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "dashi-serde", derive(Serialize, Deserialize))]
+pub enum QueueType {
+    Graphics,
+    Compute,
+    Transfer,
+}
+
 #[derive(Hash, Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "dashi-serde", derive(Serialize, Deserialize))]
 pub enum Format {


### PR DESCRIPTION
## Summary
- Add `QueueType` enum to describe graphics, compute, and transfer queues
- Extend `Context` to track compute/transfer queues with their own command pools
- Initialize all queue families with fallbacks and expose `Context::queue` helper

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abd276a9cc832ab8602f1bd002f9c3