### PR TITLE
Add queue-specific submission and pipeline stage handling

### DIFF
--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -258,7 +258,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3, QueueType::Graphics);
     let sems = ctx.make_semaphores(2).unwrap();
     'running: loop {
         // Reset the allocator

--- a/examples/minifb_triangle.rs
+++ b/examples/minifb_triangle.rs
@@ -269,7 +269,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3, QueueType::Graphics);
     let sems = ctx.make_semaphores(2).unwrap();
     'running: while display.minifb_window().is_open() {
         // Reset the allocator

--- a/examples/openxr_simple_scene.rs
+++ b/examples/openxr_simple_scene.rs
@@ -204,7 +204,7 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
 
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2, QueueType::Graphics);
 
     for _ in 0..100 {
         allocator.reset();

--- a/examples/openxr_triangle.rs
+++ b/examples/openxr_triangle.rs
@@ -186,7 +186,7 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
 
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2, QueueType::Graphics);
 
     for _ in 0..100 {
         allocator.reset();

--- a/src/gpu/structs.rs
+++ b/src/gpu/structs.rs
@@ -33,6 +33,22 @@ pub enum QueueType {
     Transfer,
 }
 
+#[derive(Hash, Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "dashi-serde", derive(Serialize, Deserialize))]
+pub enum PipelineStage {
+    TopOfPipe,
+    DrawIndirect,
+    VertexInput,
+    VertexShader,
+    FragmentShader,
+    ComputeShader,
+    Transfer,
+    ColorAttachmentOutput,
+    BottomOfPipe,
+    Host,
+    AllCommands,
+}
+
 #[derive(Hash, Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "dashi-serde", derive(Serialize, Deserialize))]
 pub enum Format {
@@ -329,6 +345,7 @@ impl<'a> Default for DynamicAllocatorInfo<'a> {
 pub struct CommandListInfo<'a> {
     pub debug_name: &'a str,
     pub should_cleanup: bool,
+    pub queue_type: QueueType,
 }
 
 impl<'a> Default for CommandListInfo<'a> {
@@ -336,19 +353,24 @@ impl<'a> Default for CommandListInfo<'a> {
         Self {
             debug_name: "",
             should_cleanup: true,
+            queue_type: QueueType::Graphics,
         }
     }
 }
 
 pub struct SubmitInfo<'a> {
+    pub queue_type: QueueType,
     pub wait_sems: &'a [Handle<Semaphore>],
+    pub wait_stages: &'a [PipelineStage],
     pub signal_sems: &'a [Handle<Semaphore>],
 }
 
 impl<'a> Default for SubmitInfo<'a> {
     fn default() -> Self {
         Self {
+            queue_type: QueueType::Graphics,
             wait_sems: &[],
+            wait_stages: &[],
             signal_sems: &[],
         }
     }

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -261,7 +261,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3, QueueType::Graphics);
     let sems = ctx.make_semaphores(2).unwrap();
     'running: loop {
         // Reset the allocator

--- a/tests/minifb_triangle.rs
+++ b/tests/minifb_triangle.rs
@@ -265,7 +265,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3, QueueType::Graphics);
     let sems = ctx.make_semaphores(2).unwrap();
     'running: while display.minifb_window().is_open() {
         // Reset the allocator

--- a/tests/openxr_triangle.rs
+++ b/tests/openxr_triangle.rs
@@ -114,7 +114,7 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
     let bind_group = ctx.make_bind_group(&BindGroupInfo{debug_name:"OpenXR Triangle",layout:bg_layout,bindings:&[BindingInfo{resource:ShaderResource::Dynamic(&allocator),binding:0}],..Default::default()}).unwrap();
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx,"Default",2);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2, QueueType::Graphics);
     allocator.reset();
     let (_idx,state) = ctx.acquire_xr_image(&mut display).unwrap();
     framed_list.record(|list|{


### PR DESCRIPTION
## Summary
- track queue type in command lists and submission info
- allow specifying wait pipeline stages for submissions
- route command buffers to appropriate queues and pools
- update framed command list to carry queue type

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abd5e78bcc832a966d7a31b88d2e18