### PR TITLE
Add basic driver types and usage flags

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,1 +1,2 @@
 pub mod ir;
+pub mod types;

--- a/src/driver/types.rs
+++ b/src/driver/types.rs
@@ -1,0 +1,51 @@
+use bitflags::bitflags;
+
+#[repr(transparent)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct PipelineHandle(pub u32);
+
+#[repr(transparent)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct BufferHandle(pub u32);
+
+#[repr(transparent)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct TextureHandle(pub u32);
+
+#[repr(transparent)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct BindTableHandle(pub u32);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Format {
+    Unknown,
+    R8Uint,
+    R8Sint,
+    RGBA8,
+    RGBA8Unorm,
+    RGBA32Float,
+    BGRA8Unorm,
+    D24S8,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum IndexType {
+    U16,
+    U32,
+}
+
+bitflags! {
+    #[derive(Default)]
+    pub struct UsageBits: u32 {
+        const SAMPLED     = 0x1;
+        const RT_WRITE    = 0x2;
+        const UAV_READ    = 0x4;
+        const UAV_WRITE   = 0x8;
+        const COPY_SRC    = 0x10;
+        const COPY_DST    = 0x20;
+        const PRESENT     = 0x40;
+        const DEPTH_READ  = 0x80;
+        const DEPTH_WRITE = 0x100;
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod utils;
 pub mod driver;
 
+pub use driver::types::{
+    BindTableHandle, BufferHandle, Format, IndexType, PipelineHandle, TextureHandle, UsageBits,
+};
+
 #[cfg(feature = "vulkan")]
 pub mod gpu;
 #[cfg(feature = "dx12")]


### PR DESCRIPTION
## Summary
- introduce typed handles and enums in `driver::types`
- expose usage bitflags for texture/buffer operations
- re-export driver types at crate root for consumers

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68ad0ed814c0832ab144ed1d4092aa63