### PR TITLE
feat(driver): add resource state tracking

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,2 +1,3 @@
 pub mod ir;
 pub mod types;
+pub mod state;

--- a/src/driver/state.rs
+++ b/src/driver/state.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+
+use super::{
+    ir::{BufferBarrier, TextureBarrier},
+    types::{BufferHandle, TextureHandle, UsageBits},
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct SubresourceRange {
+    pub base_mip: u32,
+    pub level_count: u32,
+    pub base_layer: u32,
+    pub layer_count: u32,
+}
+
+impl SubresourceRange {
+    pub fn new(base_mip: u32, level_count: u32, base_layer: u32, layer_count: u32) -> Self {
+        Self { base_mip, level_count, base_layer, layer_count }
+    }
+}
+
+#[derive(Default)]
+pub struct StateTracker {
+    textures: HashMap<(TextureHandle, SubresourceRange), UsageBits>,
+    buffers: HashMap<BufferHandle, UsageBits>,
+}
+
+impl StateTracker {
+    pub fn new() -> Self {
+        Self { textures: HashMap::new(), buffers: HashMap::new() }
+    }
+
+    pub fn request_texture_state(
+        &mut self,
+        texture: TextureHandle,
+        range: SubresourceRange,
+        usage: UsageBits,
+    ) -> Option<TextureBarrier> {
+        let key = (texture, range);
+        let current = self.textures.get(&key).copied().unwrap_or_default();
+        if current != usage {
+            self.textures.insert(key, usage);
+            Some(TextureBarrier { texture_id: texture.0 })
+        } else {
+            None
+        }
+    }
+
+    pub fn request_buffer_state(
+        &mut self,
+        buffer: BufferHandle,
+        usage: UsageBits,
+    ) -> Option<BufferBarrier> {
+        let current = self.buffers.get(&buffer).copied().unwrap_or_default();
+        if current != usage {
+            self.buffers.insert(buffer, usage);
+            Some(BufferBarrier { buffer_id: buffer.0 })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "vulkan")]
+pub mod vulkan {
+    use super::*;
+    use ash::vk;
+
+    pub const USAGE_TO_LAYOUT: &[(UsageBits, vk::ImageLayout)] = &[
+        (UsageBits::SAMPLED, vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL),
+        (UsageBits::RT_WRITE, vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL),
+        (UsageBits::UAV_READ, vk::ImageLayout::GENERAL),
+        (UsageBits::UAV_WRITE, vk::ImageLayout::GENERAL),
+        (UsageBits::COPY_SRC, vk::ImageLayout::TRANSFER_SRC_OPTIMAL),
+        (UsageBits::COPY_DST, vk::ImageLayout::TRANSFER_DST_OPTIMAL),
+        (UsageBits::PRESENT, vk::ImageLayout::PRESENT_SRC_KHR),
+        (UsageBits::DEPTH_READ, vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL),
+        (UsageBits::DEPTH_WRITE, vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
+    ];
+
+    pub const USAGE_TO_STAGE: &[(UsageBits, vk::PipelineStageFlags)] = &[
+        (UsageBits::SAMPLED, vk::PipelineStageFlags::FRAGMENT_SHADER),
+        (UsageBits::RT_WRITE, vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT),
+        (UsageBits::UAV_READ, vk::PipelineStageFlags::COMPUTE_SHADER),
+        (UsageBits::UAV_WRITE, vk::PipelineStageFlags::COMPUTE_SHADER),
+        (UsageBits::COPY_SRC, vk::PipelineStageFlags::TRANSFER),
+        (UsageBits::COPY_DST, vk::PipelineStageFlags::TRANSFER),
+        (UsageBits::PRESENT, vk::PipelineStageFlags::BOTTOM_OF_PIPE),
+        (UsageBits::DEPTH_READ, vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS),
+        (UsageBits::DEPTH_WRITE, vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS),
+    ];
+
+    pub const USAGE_TO_ACCESS: &[(UsageBits, vk::AccessFlags)] = &[
+        (UsageBits::SAMPLED, vk::AccessFlags::SHADER_READ),
+        (UsageBits::RT_WRITE, vk::AccessFlags::COLOR_ATTACHMENT_WRITE),
+        (UsageBits::UAV_READ, vk::AccessFlags::SHADER_READ),
+        (UsageBits::UAV_WRITE, vk::AccessFlags::SHADER_WRITE),
+        (UsageBits::COPY_SRC, vk::AccessFlags::TRANSFER_READ),
+        (UsageBits::COPY_DST, vk::AccessFlags::TRANSFER_WRITE),
+        (UsageBits::PRESENT, vk::AccessFlags::empty()),
+        (UsageBits::DEPTH_READ, vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ),
+        (UsageBits::DEPTH_WRITE, vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE),
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn texture_state_changes() {
+        let mut tracker = StateTracker::new();
+        let tex = TextureHandle(1);
+        let range = SubresourceRange::new(0, 1, 0, 1);
+        assert!(tracker.request_texture_state(tex, range, UsageBits::SAMPLED).is_some());
+        assert!(tracker.request_texture_state(tex, range, UsageBits::SAMPLED).is_none());
+        assert!(tracker.request_texture_state(tex, range, UsageBits::RT_WRITE).is_some());
+    }
+
+    #[test]
+    fn buffer_state_changes() {
+        let mut tracker = StateTracker::new();
+        let buf = BufferHandle(1);
+        assert!(tracker.request_buffer_state(buf, UsageBits::COPY_SRC).is_some());
+        assert!(tracker.request_buffer_state(buf, UsageBits::COPY_SRC).is_none());
+        assert!(tracker.request_buffer_state(buf, UsageBits::COPY_DST).is_some());
+    }
+}

--- a/src/driver/types.rs
+++ b/src/driver/types.rs
@@ -35,7 +35,7 @@ pub enum IndexType {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct UsageBits: u32 {
         const SAMPLED     = 0x1;
         const RT_WRITE    = 0x2;

--- a/src/gpu/builders.rs
+++ b/src/gpu/builders.rs
@@ -524,6 +524,7 @@ mod tests {
     use super::*;
     use crate::ContextInfo;
     use crate::*;
+    use crate::gpu::structs::Format as GpuFormat;
     use serial_test::serial;
     use std::panic;
 
@@ -694,7 +695,7 @@ mod tests {
 
         // 1) single subpass, only color
         let color_desc = AttachmentDescription {
-            format: Format::RGBA8,
+            format: GpuFormat::RGBA8,
             samples: SampleCount::S1,
             load_op: LoadOp::Clear,
             store_op: StoreOp::Store,
@@ -717,7 +718,7 @@ mod tests {
 
         // 2) with depth+stencil attachment
         let ds_desc = AttachmentDescription {
-            format: Format::D24S8,
+            format: GpuFormat::D24S8,
             samples: SampleCount::S1,
             load_op: LoadOp::Clear,
             store_op: StoreOp::DontCare,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod utils;
 pub mod driver;
 
 pub use driver::types::{
-    BindTableHandle, BufferHandle, Format, IndexType, PipelineHandle, TextureHandle, UsageBits,
+    BindTableHandle, BufferHandle, IndexType, PipelineHandle, TextureHandle, UsageBits,
 };
 
 #[cfg(feature = "vulkan")]


### PR DESCRIPTION
## Summary
- track buffer and texture usage and emit barriers when state changes
- map usage bits to Vulkan layout/stage/access tables
- exercise state transitions with new unit tests

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad11f22654832a866e1bd80c9c8fdb