### PR TITLE
Add command encoder with automatic barriers

### DIFF
--- a/src/driver/encoder.rs
+++ b/src/driver/encoder.rs
@@ -1,0 +1,139 @@
+use super::{
+    ir::{
+        CommandStream, Op, BeginRenderPass, EndRenderPass, BindPipeline, BindTable, Draw, Dispatch,
+        CopyBuffer, CopyTexture, DebugMarkerBegin, DebugMarkerEnd,
+    },
+    state::{StateTracker, SubresourceRange},
+    types::{BindTableHandle, BufferHandle, PipelineHandle, TextureHandle, UsageBits},
+};
+
+/// Encoder records high level operations into a [`CommandStream`].
+/// It also uses [`StateTracker`] to automatically emit resource barriers
+/// whenever resource usage changes.
+pub struct Encoder {
+    stream: CommandStream,
+    state: StateTracker,
+}
+
+impl Encoder {
+    /// Create a new empty encoder.
+    pub fn new() -> Self {
+        Self { stream: CommandStream::new(), state: StateTracker::new() }
+    }
+
+    /// Finish recording and return the underlying command stream.
+    pub fn finish(self) -> CommandStream {
+        self.stream
+    }
+
+    /// Begin a render pass with a single color attachment.
+    pub fn begin_render_pass(&mut self, color: TextureHandle, range: SubresourceRange) {
+        if let Some(bar) = self.state.request_texture_state(color, range, UsageBits::RT_WRITE) {
+            self.stream.push(Op::TextureBarrier, &bar);
+        }
+        let payload = BeginRenderPass { color_attachments: color.0 };
+        self.stream.push(Op::BeginRenderPass, &payload);
+    }
+
+    /// End the current render pass.
+    pub fn end_render_pass(&mut self) {
+        self.stream.push(Op::EndRenderPass, &EndRenderPass {});
+    }
+
+    /// Bind a graphics or compute pipeline.
+    pub fn bind_pipeline(&mut self, pipe: PipelineHandle) {
+        let payload = BindPipeline { pipeline_id: pipe.0 };
+        self.stream.push(Op::BindPipeline, &payload);
+    }
+
+    /// Bind a table of resources.
+    pub fn bind_table(&mut self, table: BindTableHandle) {
+        let payload = BindTable { table_id: table.0 };
+        self.stream.push(Op::BindTable, &payload);
+    }
+
+    /// Issue a draw call.
+    pub fn draw(&mut self, vertex_count: u32, instance_count: u32) {
+        let payload = Draw { vertex_count, instance_count };
+        self.stream.push(Op::Draw, &payload);
+    }
+
+    /// Issue a dispatch call.
+    pub fn dispatch(&mut self, x: u32, y: u32, z: u32) {
+        let payload = Dispatch { x, y, z };
+        self.stream.push(Op::Dispatch, &payload);
+    }
+
+    /// Copy data between buffers. Barriers for source and destination
+    /// are emitted automatically.
+    pub fn copy_buffer(&mut self, src: BufferHandle, dst: BufferHandle) {
+        if let Some(bar) = self.state.request_buffer_state(src, UsageBits::COPY_SRC) {
+            self.stream.push(Op::BufferBarrier, &bar);
+        }
+        if let Some(bar) = self.state.request_buffer_state(dst, UsageBits::COPY_DST) {
+            self.stream.push(Op::BufferBarrier, &bar);
+        }
+        let payload = CopyBuffer { src: src.0, dst: dst.0 };
+        self.stream.push(Op::CopyBuffer, &payload);
+    }
+
+    /// Copy data between textures, emitting required barriers.
+    pub fn copy_texture(&mut self, src: TextureHandle, dst: TextureHandle, range: SubresourceRange) {
+        if let Some(bar) = self.state.request_texture_state(src, range, UsageBits::COPY_SRC) {
+            self.stream.push(Op::TextureBarrier, &bar);
+        }
+        if let Some(bar) = self.state.request_texture_state(dst, range, UsageBits::COPY_DST) {
+            self.stream.push(Op::TextureBarrier, &bar);
+        }
+        let payload = CopyTexture { src: src.0, dst: dst.0 };
+        self.stream.push(Op::CopyTexture, &payload);
+    }
+
+    /// Begin a debug marker region.
+    pub fn begin_debug_marker(&mut self) {
+        self.stream.push(Op::DebugMarkerBegin, &DebugMarkerBegin {});
+    }
+
+    /// End a debug marker region.
+    pub fn end_debug_marker(&mut self) {
+        self.stream.push(Op::DebugMarkerEnd, &DebugMarkerEnd {});
+    }
+}
+
+impl Default for Encoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn barriers_are_emitted() {
+        let mut enc = Encoder::new();
+        let tex = TextureHandle(1);
+        let range = SubresourceRange::new(0, 1, 0, 1);
+        enc.begin_render_pass(tex, range);
+        enc.end_render_pass();
+        let stream = enc.finish();
+        let cmds: Vec<_> = stream.iter().collect();
+        assert_eq!(cmds[0].op, Op::TextureBarrier);
+        assert_eq!(cmds[1].op, Op::BeginRenderPass);
+        assert_eq!(cmds[2].op, Op::EndRenderPass);
+    }
+
+    #[test]
+    fn copy_buffer_emits_barriers() {
+        let mut enc = Encoder::new();
+        let src = BufferHandle(2);
+        let dst = BufferHandle(3);
+        enc.copy_buffer(src, dst);
+        let stream = enc.finish();
+        let cmds: Vec<_> = stream.iter().collect();
+        assert_eq!(cmds[0].op, Op::BufferBarrier);
+        assert_eq!(cmds[1].op, Op::BufferBarrier);
+        assert_eq!(cmds[2].op, Op::CopyBuffer);
+    }
+}

--- a/src/driver/ir.rs
+++ b/src/driver/ir.rs
@@ -4,9 +4,17 @@ use bytemuck::{bytes_of, from_bytes, Pod, Zeroable};
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Op {
     BeginRenderPass = 0,
-    Draw = 1,
-    TextureBarrier = 2,
-    BufferBarrier = 3,
+    EndRenderPass = 1,
+    BindPipeline = 2,
+    BindTable = 3,
+    Draw = 4,
+    Dispatch = 5,
+    CopyBuffer = 6,
+    CopyTexture = 7,
+    TextureBarrier = 8,
+    BufferBarrier = 9,
+    DebugMarkerBegin = 10,
+    DebugMarkerEnd = 11,
 }
 
 #[repr(C)]
@@ -17,9 +25,47 @@ pub struct BeginRenderPass {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct EndRenderPass {}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct BindPipeline {
+    pub pipeline_id: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct BindTable {
+    pub table_id: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
 pub struct Draw {
     pub vertex_count: u32,
     pub instance_count: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct Dispatch {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct CopyBuffer {
+    pub src: u32,
+    pub dst: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct CopyTexture {
+    pub src: u32,
+    pub dst: u32,
 }
 
 #[repr(C)]
@@ -33,6 +79,14 @@ pub struct TextureBarrier {
 pub struct BufferBarrier {
     pub buffer_id: u32,
 }
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct DebugMarkerBegin {}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
+pub struct DebugMarkerEnd {}
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
@@ -99,9 +153,17 @@ impl Op {
     fn from_u16(v: u16) -> Option<Self> {
         match v {
             x if x == Op::BeginRenderPass as u16 => Some(Op::BeginRenderPass),
+            x if x == Op::EndRenderPass as u16 => Some(Op::EndRenderPass),
+            x if x == Op::BindPipeline as u16 => Some(Op::BindPipeline),
+            x if x == Op::BindTable as u16 => Some(Op::BindTable),
             x if x == Op::Draw as u16 => Some(Op::Draw),
+            x if x == Op::Dispatch as u16 => Some(Op::Dispatch),
+            x if x == Op::CopyBuffer as u16 => Some(Op::CopyBuffer),
+            x if x == Op::CopyTexture as u16 => Some(Op::CopyTexture),
             x if x == Op::TextureBarrier as u16 => Some(Op::TextureBarrier),
             x if x == Op::BufferBarrier as u16 => Some(Op::BufferBarrier),
+            x if x == Op::DebugMarkerBegin as u16 => Some(Op::DebugMarkerBegin),
+            x if x == Op::DebugMarkerEnd as u16 => Some(Op::DebugMarkerEnd),
             _ => None,
         }
     }
@@ -115,14 +177,26 @@ mod tests {
     fn round_trip() {
         let mut stream = CommandStream::new();
         let begin = BeginRenderPass { color_attachments: 1 };
+        let end = EndRenderPass {};
+        let bind = BindPipeline { pipeline_id: 2 };
         let draw = Draw { vertex_count: 3, instance_count: 1 };
+        let dispatch = Dispatch { x: 1, y: 2, z: 3 };
+        let copy = CopyBuffer { src: 4, dst: 5 };
         let tex_barrier = TextureBarrier { texture_id: 7 };
         let buf_barrier = BufferBarrier { buffer_id: 9 };
+        let marker_begin = DebugMarkerBegin {};
+        let marker_end = DebugMarkerEnd {};
 
         stream.push(Op::BeginRenderPass, &begin);
+        stream.push(Op::EndRenderPass, &end);
+        stream.push(Op::BindPipeline, &bind);
         stream.push(Op::Draw, &draw);
+        stream.push(Op::Dispatch, &dispatch);
+        stream.push(Op::CopyBuffer, &copy);
         stream.push(Op::TextureBarrier, &tex_barrier);
         stream.push(Op::BufferBarrier, &buf_barrier);
+        stream.push(Op::DebugMarkerBegin, &marker_begin);
+        stream.push(Op::DebugMarkerEnd, &marker_end);
 
         let mut iter = stream.iter();
 
@@ -131,16 +205,40 @@ mod tests {
         assert_eq!(*cmd1.payload::<BeginRenderPass>(), begin);
 
         let cmd2 = iter.next().unwrap();
-        assert_eq!(cmd2.op, Op::Draw);
-        assert_eq!(*cmd2.payload::<Draw>(), draw);
+        assert_eq!(cmd2.op, Op::EndRenderPass);
+        assert_eq!(*cmd2.payload::<EndRenderPass>(), end);
 
         let cmd3 = iter.next().unwrap();
-        assert_eq!(cmd3.op, Op::TextureBarrier);
-        assert_eq!(*cmd3.payload::<TextureBarrier>(), tex_barrier);
+        assert_eq!(cmd3.op, Op::BindPipeline);
+        assert_eq!(*cmd3.payload::<BindPipeline>(), bind);
 
         let cmd4 = iter.next().unwrap();
-        assert_eq!(cmd4.op, Op::BufferBarrier);
-        assert_eq!(*cmd4.payload::<BufferBarrier>(), buf_barrier);
+        assert_eq!(cmd4.op, Op::Draw);
+        assert_eq!(*cmd4.payload::<Draw>(), draw);
+
+        let cmd5 = iter.next().unwrap();
+        assert_eq!(cmd5.op, Op::Dispatch);
+        assert_eq!(*cmd5.payload::<Dispatch>(), dispatch);
+
+        let cmd6 = iter.next().unwrap();
+        assert_eq!(cmd6.op, Op::CopyBuffer);
+        assert_eq!(*cmd6.payload::<CopyBuffer>(), copy);
+
+        let cmd7 = iter.next().unwrap();
+        assert_eq!(cmd7.op, Op::TextureBarrier);
+        assert_eq!(*cmd7.payload::<TextureBarrier>(), tex_barrier);
+
+        let cmd8 = iter.next().unwrap();
+        assert_eq!(cmd8.op, Op::BufferBarrier);
+        assert_eq!(*cmd8.payload::<BufferBarrier>(), buf_barrier);
+
+        let cmd9 = iter.next().unwrap();
+        assert_eq!(cmd9.op, Op::DebugMarkerBegin);
+        assert_eq!(*cmd9.payload::<DebugMarkerBegin>(), marker_begin);
+
+        let cmd10 = iter.next().unwrap();
+        assert_eq!(cmd10.op, Op::DebugMarkerEnd);
+        assert_eq!(*cmd10.payload::<DebugMarkerEnd>(), marker_end);
 
         assert!(iter.next().is_none());
     }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,3 +1,4 @@
 pub mod ir;
 pub mod types;
 pub mod state;
+pub mod encoder;


### PR DESCRIPTION
## Summary
- add `Encoder` for recording operations into a `CommandStream`
- extend IR with additional ops and export the encoder
- include unit tests verifying automatic barrier emission

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad197dfe40832ab28afa1153244e93