### PR TITLE
Introduce render target abstraction for drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the full mip chain after the initial data upload.
 Switching graphics pipelines without ending the render pass:
 
 ```rust
-list.begin_drawing(&DrawBegin { pipeline: first, viewport, attachments })?;
+list.begin_drawing(&DrawBegin { pipeline: first, viewport, render_target, clear_values })?;
 list.append(Command::Draw(my_draw));
 list.bind_pipeline(second)?; // change pipelines mid-pass
 list.append(Command::Draw(other_draw));

--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -226,6 +226,14 @@ void main() {
         })
         .unwrap();
 
+    let render_target = ctx
+        .make_render_target(&RenderTargetInfo {
+            debug_name: "rt",
+            render_pass,
+            attachments: &[fb_view],
+        })
+        .unwrap();
+
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -305,10 +313,8 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                attachments: &[Attachment {
-                    img: fb_view,
-                    clear: ClearValue::Color([0.0, 0.0, 0.0, 1.0]),
-                }],
+                render_target,
+                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
             })
             .unwrap();
 

--- a/examples/minifb_triangle.rs
+++ b/examples/minifb_triangle.rs
@@ -237,6 +237,14 @@ void main() {
         })
         .unwrap();
 
+    let render_target = ctx
+        .make_render_target(&RenderTargetInfo {
+            debug_name: "rt",
+            render_pass,
+            attachments: &[fb_view],
+        })
+        .unwrap();
+
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -300,10 +308,8 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                attachments: &[Attachment {
-                    img: fb_view,
-                    clear: ClearValue::Color([0.0, 0.0, 0.0, 1.0]),
-                }],
+                render_target,
+                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
             })
             .unwrap();
 

--- a/examples/openxr_simple_scene.rs
+++ b/examples/openxr_simple_scene.rs
@@ -183,6 +183,14 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
         })
         .unwrap();
 
+    let render_target = ctx
+        .make_render_target(&RenderTargetInfo {
+            debug_name: "rt",
+            render_pass,
+            attachments: &[fb_view],
+        })
+        .unwrap();
+
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
             layout: pipeline_layout,
@@ -227,7 +235,8 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                attachments: &[Attachment { img: fb_view, clear: ClearValue::Color([0.0, 0.0, 0.0, 1.0]) }],
+                render_target,
+                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
             }).unwrap();
             let mut buf = allocator.bump().unwrap();
             let mut mat = &mut buf.slice::<[f32; 16]>()[0];

--- a/examples/openxr_triangle.rs
+++ b/examples/openxr_triangle.rs
@@ -165,6 +165,14 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
         })
         .unwrap();
 
+    let render_target = ctx
+        .make_render_target(&RenderTargetInfo {
+            debug_name: "rt",
+            render_pass,
+            attachments: &[fb_view],
+        })
+        .unwrap();
+
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
             layout: pipeline_layout,
@@ -200,7 +208,8 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                attachments: &[Attachment { img: fb_view, clear: ClearValue::Color([0.0, 0.0, 0.0, 1.0]) }],
+                render_target,
+                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
             }).unwrap();
             let mut buf = allocator.bump().unwrap();
             let pos = &mut buf.slice::<[f32; 2]>()[0];

--- a/src/gpu/vulkan/structs.rs
+++ b/src/gpu/vulkan/structs.rs
@@ -847,6 +847,12 @@ pub struct RenderPassInfo<'a> {
     pub subpasses: &'a [SubpassDescription<'a>],
 }
 
+pub struct RenderTargetInfo<'a> {
+    pub debug_name: &'a str,
+    pub render_pass: Handle<RenderPass>,
+    pub attachments: &'a [Handle<ImageView>],
+}
+
 #[derive(Hash, Debug, Clone)]
 pub struct VertexDescriptionInfo<'a> {
     pub entries: &'a [VertexEntryInfo], // ConstSlice in Rust can be a reference slice

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -229,6 +229,14 @@ void main() {
         })
         .unwrap();
 
+    let render_target = ctx
+        .make_render_target(&RenderTargetInfo {
+            debug_name: "rt",
+            render_pass,
+            attachments: &[fb_view],
+        })
+        .unwrap();
+
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -308,10 +316,8 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                attachments: &[Attachment {
-                    img: fb_view,
-                    clear: ClearValue::Color([0.0, 0.0, 0.0, 1.0]),
-                }],
+                render_target,
+                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
             })
             .unwrap();
 

--- a/tests/minifb_triangle.rs
+++ b/tests/minifb_triangle.rs
@@ -233,6 +233,14 @@ void main() {
         })
         .unwrap();
 
+    let render_target = ctx
+        .make_render_target(&RenderTargetInfo {
+            debug_name: "rt",
+            render_pass,
+            attachments: &[fb_view],
+        })
+        .unwrap();
+
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -296,10 +304,8 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                attachments: &[Attachment {
-                    img: fb_view,
-                    clear: ClearValue::Color([0.0, 0.0, 0.0, 1.0]),
-                }],
+                render_target,
+                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
             })
             .unwrap();
 

--- a/tests/openxr_triangle.rs
+++ b/tests/openxr_triangle.rs
@@ -109,6 +109,7 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
         subpasses:&[SubpassDescription{color_attachments:&[AttachmentDescription{..Default::default()}],depth_stencil_attachment:None,subpass_dependencies:&[]}],
         debug_name:"renderpass"
     }).unwrap();
+    let render_target = ctx.make_render_target(&RenderTargetInfo{debug_name:"rt",render_pass,attachments:&[fb_view]}).unwrap();
     let graphics_pipeline = ctx.make_graphics_pipeline(&GraphicsPipelineInfo{layout:pipeline_layout,render_pass,debug_name:"Pipeline",..Default::default()}).unwrap();
     let mut allocator = ctx.make_dynamic_allocator(&Default::default()).unwrap();
     let bind_group = ctx.make_bind_group(&BindGroupInfo{debug_name:"OpenXR Triangle",layout:bg_layout,bindings:&[BindingInfo{resource:ShaderResource::Dynamic(&allocator),binding:0}],..Default::default()}).unwrap();
@@ -121,7 +122,8 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
         list.begin_drawing(&DrawBegin{
             viewport:Viewport{area:FRect2D{w:width as f32,h:height as f32,..Default::default()},scissor:Rect2D{w:width,h:height,..Default::default()},..Default::default()},
             pipeline:graphics_pipeline,
-            attachments:&[Attachment{img:fb_view,clear:ClearValue::Color([0.0,0.0,0.0,1.0])}]
+            render_target,
+            clear_values:&[ClearValue::Color([0.0,0.0,0.0,1.0])]
         }).unwrap();
         let mut buf=allocator.bump().unwrap();
         let pos=&mut buf.slice::<[f32;2]>()[0];

--- a/tests/pipeline_switch.rs
+++ b/tests/pipeline_switch.rs
@@ -38,6 +38,14 @@ fn pipeline_switch() {
         })
         .unwrap();
 
+    let rt = ctx
+        .make_render_target(&RenderTargetInfo {
+            debug_name: "rt",
+            render_pass: rp,
+            attachments: &[view],
+        })
+        .unwrap();
+
     let vert = inline_spirv::inline_spirv!(r"#version 450
         vec2 positions[3] = vec2[3](vec2(-0.5,-0.5), vec2(0.5,-0.5), vec2(0.0,0.5));
         void main() {
@@ -122,7 +130,8 @@ fn pipeline_switch() {
             ..Default::default()
         },
         pipeline: pipe_red,
-        attachments: &[Attachment { img: view, clear: ClearValue::Color([0.0,0.0,0.0,1.0]) }],
+        render_target: rt,
+        clear_values: &[ClearValue::Color([0.0,0.0,0.0,1.0])],
     }).unwrap();
 
     list.append(Command::Draw(Draw { vertices: vb, count: 3, ..Default::default() }));


### PR DESCRIPTION
## Summary
- add RenderTarget resource and validation
- begin drawing via RenderTarget instead of ad-hoc attachments
- update examples and tests for new API

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae028fedd4832ab5f35a99dbacb8ab