### PR TITLE
Rename texture handle to image

### DIFF
--- a/src/driver/command.rs
+++ b/src/driver/command.rs
@@ -133,7 +133,7 @@ pub struct CopyImage {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
 pub struct ImageBarrier {
-    pub texture: Handle<Image>,
+    pub image: Handle<Image>,
     pub range: SubresourceRange,
 }
 
@@ -256,7 +256,7 @@ impl CommandEncoder {
         self.push(Op::CopyBuffer, &payload);
     }
 
-    /// Copy data between textures, emitting required barriers.
+    /// Copy data between images, emitting required barriers.
     pub fn copy_texture(
         &mut self,
         src: Handle<Image>,
@@ -440,7 +440,7 @@ mod tests {
         let draw = Draw { vertex_count: 3, instance_count: 1 };
         let dispatch = Dispatch { x: 1, y: 2, z: 3 };
         let copy = CopyBuffer { src: Handle::<Buffer>::new(4, 0), dst: Handle::<Buffer>::new(5, 0) };
-        let tex_barrier = ImageBarrier { texture: Handle::<Image>::new(7, 0), range: SubresourceRange::new(0,1,0,1) };
+        let img_barrier = ImageBarrier { image: Handle::<Image>::new(7, 0), range: SubresourceRange::new(0,1,0,1) };
         let buf_barrier = BufferBarrier { buffer: Handle::<Buffer>::new(9, 0) };
         let marker_begin = DebugMarkerBegin {};
         let marker_end = DebugMarkerEnd {};
@@ -451,7 +451,7 @@ mod tests {
         enc.push(Op::Draw, &draw);
         enc.push(Op::Dispatch, &dispatch);
         enc.push(Op::CopyBuffer, &copy);
-        enc.push(Op::ImageBarrier, &tex_barrier);
+        enc.push(Op::ImageBarrier, &img_barrier);
         enc.push(Op::BufferBarrier, &buf_barrier);
         enc.push(Op::DebugMarkerBegin, &marker_begin);
         enc.push(Op::DebugMarkerEnd, &marker_end);
@@ -484,7 +484,7 @@ mod tests {
 
         let cmd7 = iter.next().unwrap();
         assert_eq!(cmd7.op, Op::ImageBarrier);
-        assert_eq!(*cmd7.payload::<ImageBarrier>(), tex_barrier);
+        assert_eq!(*cmd7.payload::<ImageBarrier>(), img_barrier);
 
         let cmd8 = iter.next().unwrap();
         assert_eq!(cmd8.op, Op::BufferBarrier);

--- a/src/driver/state.rs
+++ b/src/driver/state.rs
@@ -37,15 +37,15 @@ impl StateTracker {
 
     pub fn request_texture_state(
         &mut self,
-        texture: Handle<Image>,
+        image: Handle<Image>,
         range: SubresourceRange,
         usage: UsageBits,
     ) -> Option<ImageBarrier> {
-        let key = (texture, range);
+        let key = (image, range);
         let current = self.textures.get(&key).copied().unwrap_or_default();
         if current != usage {
             self.textures.insert(key, usage);
-            Some(ImageBarrier { texture, range })
+            Some(ImageBarrier { image, range })
         } else {
             None
         }

--- a/src/driver/types.rs
+++ b/src/driver/types.rs
@@ -5,7 +5,7 @@ pub use crate::utils::handle::Handle;
 pub struct Pipeline;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Texture;
+pub struct Image;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct BindTable;

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -1309,7 +1309,7 @@ impl CommandList {
      }
 
      fn texture_barrier(&mut self, _cmd: &crate::driver::command::ImageBarrier) {
-//        let barrier = ImageBarrier { view: Handle::new(cmd.texture.index(), cmd.texture.version()), src: BarrierPoint::BlitRead, dst: BarrierPoint::BlitWrite };
+//        let barrier = ImageBarrier { view: Handle::new(cmd.image.index(), cmd.image.version()), src: BarrierPoint::BlitRead, dst: BarrierPoint::BlitWrite };
 //        self.image_barrier(barrier);
      }
  


### PR DESCRIPTION
## Summary
- replace Texture marker type with Image
- rename ImageBarrier field to `image`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3abbcca4832a851a44f3ecf829fc