### PR TITLE
Add Vulkan IR replayer

### DIFF
--- a/src/gpu/vulkan/framed_cmd_list.rs
+++ b/src/gpu/vulkan/framed_cmd_list.rs
@@ -1,4 +1,12 @@
-use crate::{utils::Handle, CommandList, CommandListInfo, Context, Fence, SubmitInfo};
+use crate::{
+    driver::command::CommandEncoder,
+    utils::Handle,
+    CommandList,
+    CommandListInfo,
+    Context,
+    Fence,
+    SubmitInfo,
+};
 
 pub struct FramedCommandList {
     cmds: Vec<CommandList>,
@@ -72,6 +80,16 @@ impl FramedCommandList {
         self.fences[self.curr as usize] = Some(unsafe {
             (*self.ctx)
                 .submit(&mut self.cmds[self.curr as usize], info)
+                .unwrap()
+        });
+
+        self.advance();
+    }
+
+    pub fn submit_encoder(&mut self, encoder: &CommandEncoder, info: &SubmitInfo) {
+        self.fences[self.curr as usize] = Some(unsafe {
+            (*self.ctx)
+                .submit_encoder(&mut self.cmds[self.curr as usize], encoder, info)
                 .unwrap()
         });
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,0 +1,3 @@
+pub mod replay_vk;
+
+pub use replay_vk::VkReplayer;

--- a/src/ir/replay_vk.rs
+++ b/src/ir/replay_vk.rs
@@ -1,0 +1,63 @@
+use crate::driver::command::{
+    BeginRenderPass, BindPipeline, BindTableCmd, BufferBarrier, CommandEncoder, CommandSink,
+    CopyBuffer, CopyImage, DebugMarkerBegin, DebugMarkerEnd, Dispatch, Draw, EndRenderPass,
+    ImageBarrier, Op as OpTag,
+};
+use crate::gpu::vulkan::CommandList;
+
+/// Replays an encoded command stream on a Vulkan [`CommandList`].
+///
+/// The replayer operates purely on [`Handle`](crate::driver::types::Handle)
+/// identifiers and resolves them to Vulkan objects through the existing
+/// registries maintained by the `CommandList`'s context.
+pub struct VkReplayer<'a> {
+    list: &'a mut CommandList,
+}
+
+impl<'a> VkReplayer<'a> {
+    /// Create a new Vulkan replayer targeting the given command list.
+    pub fn new(list: &'a mut CommandList) -> Self {
+        Self { list }
+    }
+
+    /// Iterate over the encoded command stream and issue the corresponding
+    /// Vulkan calls via the underlying command list.
+    pub fn replay(&mut self, encoder: &CommandEncoder) {
+        for cmd in encoder.iter() {
+            match cmd.op {
+                OpTag::BeginRenderPass => {
+                    CommandSink::begin_render_pass(self.list, cmd.payload::<BeginRenderPass>())
+                }
+                OpTag::EndRenderPass => {
+                    CommandSink::end_render_pass(self.list, cmd.payload::<EndRenderPass>())
+                }
+                OpTag::BindPipeline => {
+                    CommandSink::bind_pipeline(self.list, cmd.payload::<BindPipeline>())
+                }
+                OpTag::BindTable => {
+                    CommandSink::bind_table(self.list, cmd.payload::<BindTableCmd>())
+                }
+                OpTag::Draw => CommandSink::draw(self.list, cmd.payload::<Draw>()),
+                OpTag::Dispatch => CommandSink::dispatch(self.list, cmd.payload::<Dispatch>()),
+                OpTag::CopyBuffer => {
+                    CommandSink::copy_buffer(self.list, cmd.payload::<CopyBuffer>())
+                }
+                OpTag::CopyImage => {
+                    CommandSink::copy_texture(self.list, cmd.payload::<CopyImage>())
+                }
+                OpTag::ImageBarrier => {
+                    CommandSink::texture_barrier(self.list, cmd.payload::<ImageBarrier>())
+                }
+                OpTag::BufferBarrier => {
+                    CommandSink::buffer_barrier(self.list, cmd.payload::<BufferBarrier>())
+                }
+                OpTag::DebugMarkerBegin => {
+                    CommandSink::debug_marker_begin(self.list, cmd.payload::<DebugMarkerBegin>())
+                }
+                OpTag::DebugMarkerEnd => {
+                    CommandSink::debug_marker_end(self.list, cmd.payload::<DebugMarkerEnd>())
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod utils;
 pub mod driver;
+pub mod ir;
 
 pub use driver::types::{Handle, IndexType, UsageBits};
 

--- a/tests/submit_encoder.rs
+++ b/tests/submit_encoder.rs
@@ -1,0 +1,32 @@
+use dashi::{
+    driver::command::CommandEncoder,
+    *,
+};
+
+#[test]
+fn submit_encoder() {
+    let mut ctx = match gpu::Context::headless(&ContextInfo::default()) {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            eprintln!(
+                "Skipping submit_encoder test: Vulkan initialization unavailable: {:?}",
+                err
+            );
+            return;
+        }
+    };
+
+    let mut list = ctx
+        .begin_command_list(&CommandListInfo { debug_name: "encoder", ..Default::default() })
+        .unwrap();
+
+    let enc = CommandEncoder::new();
+    let fence = ctx
+        .submit_encoder(&mut list, &enc, &SubmitInfo::default())
+        .unwrap();
+    ctx.wait(fence).unwrap();
+
+    ctx.destroy_cmd_list(list);
+    ctx.destroy();
+}
+


### PR DESCRIPTION
## Summary
- Add `submit_encoder` helper on Vulkan context that replays a `CommandEncoder` and submits
- Allow `FramedCommandList` to submit encoded streams
- Test encoder submission path

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3b1f69e0832aa92acf1c1604a355