### PR TITLE
Add sync state and Vulkan barrier builder

### DIFF
--- a/src/gpu/vulkan/mod.rs
+++ b/src/gpu/vulkan/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     driver::command::CommandEncoder,
     ir::VkReplayer,
     utils::{Handle, Pool},
+    sync::ResourceLookup,
 };
 use ash::*;
 pub use error::*;
@@ -3430,5 +3431,15 @@ void main() {
         let ctx = Context::headless(&Default::default()).unwrap();
         // Bind table support is optional; ensure context can be created and cleaned up.
         ctx.destroy();
+    }
+}
+
+impl ResourceLookup for Context {
+    fn image_raw(&self, image: Handle<Image>) -> vk::Image {
+        self.images.get_ref(image).expect("invalid image").img
+    }
+
+    fn buffer_raw(&self, buffer: Handle<Buffer>) -> vk::Buffer {
+        self.buffers.get_ref(buffer).expect("invalid buffer").buf
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod utils;
 pub mod driver;
 pub mod ir;
+pub mod sync;
 
 pub use driver::types::{Handle, IndexType, UsageBits};
 

--- a/src/sync/barrier_builder.rs
+++ b/src/sync/barrier_builder.rs
@@ -1,0 +1,81 @@
+use ash::vk;
+use smallvec::SmallVec;
+
+use crate::Handle;
+use crate::sync::state::ResState;
+use crate::gpu::vulkan::{Image, Buffer};
+
+pub trait ResourceLookup {
+    fn image_raw(&self, image: Handle<Image>) -> vk::Image;
+    fn buffer_raw(&self, buffer: Handle<Buffer>) -> vk::Buffer;
+}
+
+pub struct BarrierBuilder<'a, R: ResourceLookup> {
+    lookup: &'a R,
+    images: SmallVec<[vk::ImageMemoryBarrier2; 4]>,
+    buffers: SmallVec<[vk::BufferMemoryBarrier2; 4]>,
+}
+
+impl<'a, R: ResourceLookup> BarrierBuilder<'a, R> {
+    pub fn new(lookup: &'a R) -> Self {
+        Self {
+            lookup,
+            images: SmallVec::new(),
+            buffers: SmallVec::new(),
+        }
+    }
+
+    pub fn image(&mut self, image: Handle<Image>, src: ResState, dst: ResState) {
+        if src == dst { return; }
+        let raw = self.lookup.image_raw(image);
+        let barrier = vk::ImageMemoryBarrier2 {
+            src_stage_mask: src.stages.into(),
+            src_access_mask: src.access.into(),
+            dst_stage_mask: dst.stages.into(),
+            dst_access_mask: dst.access.into(),
+            old_layout: src.layout.into(),
+            new_layout: dst.layout.into(),
+            image: raw,
+            subresource_range: vk::ImageSubresourceRange {
+                aspect_mask: vk::ImageAspectFlags::COLOR,
+                base_mip_level: 0,
+                level_count: vk::REMAINING_MIP_LEVELS,
+                base_array_layer: 0,
+                layer_count: vk::REMAINING_ARRAY_LAYERS,
+            },
+            ..Default::default()
+        };
+        self.images.push(barrier);
+    }
+
+    pub fn buffer(&mut self, buffer: Handle<Buffer>, src: ResState, dst: ResState) {
+        if src == dst { return; }
+        let raw = self.lookup.buffer_raw(buffer);
+        let barrier = vk::BufferMemoryBarrier2 {
+            src_stage_mask: src.stages.into(),
+            src_access_mask: src.access.into(),
+            dst_stage_mask: dst.stages.into(),
+            dst_access_mask: dst.access.into(),
+            src_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            dst_queue_family_index: vk::QUEUE_FAMILY_IGNORED,
+            buffer: raw,
+            offset: 0,
+            size: vk::WHOLE_SIZE,
+            ..Default::default()
+        };
+        self.buffers.push(barrier);
+    }
+
+    pub unsafe fn emit(&mut self, device: &ash::Device, cmd: vk::CommandBuffer) {
+        if self.images.is_empty() && self.buffers.is_empty() {
+            return;
+        }
+        let deps = vk::DependencyInfo::builder()
+            .image_memory_barriers(&self.images)
+            .buffer_memory_barriers(&self.buffers)
+            .build();
+        device.cmd_pipeline_barrier2(cmd, &deps);
+        self.images.clear();
+        self.buffers.clear();
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(feature = "vulkan")]
+pub mod state;
+#[cfg(feature = "vulkan")]
+pub mod barrier_builder;
+
+#[cfg(feature = "vulkan")]
+pub use barrier_builder::{BarrierBuilder, ResourceLookup};
+#[cfg(feature = "vulkan")]
+pub use state::{Access, ImageLayout, ResState, Stage};

--- a/src/sync/state.rs
+++ b/src/sync/state.rs
@@ -1,0 +1,85 @@
+use ash::vk;
+use bitflags::bitflags;
+use bytemuck::{Pod, Zeroable};
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Access: u64 {
+        const NONE = 0;
+        const INDIRECT_COMMAND_READ = vk::AccessFlags2::INDIRECT_COMMAND_READ.as_raw();
+        const INDEX_READ = vk::AccessFlags2::INDEX_READ.as_raw();
+        const VERTEX_ATTRIBUTE_READ = vk::AccessFlags2::VERTEX_ATTRIBUTE_READ.as_raw();
+        const UNIFORM_READ = vk::AccessFlags2::UNIFORM_READ.as_raw();
+        const INPUT_ATTACHMENT_READ = vk::AccessFlags2::INPUT_ATTACHMENT_READ.as_raw();
+        const SHADER_READ = vk::AccessFlags2::SHADER_READ.as_raw();
+        const SHADER_WRITE = vk::AccessFlags2::SHADER_WRITE.as_raw();
+        const COLOR_ATTACHMENT_READ = vk::AccessFlags2::COLOR_ATTACHMENT_READ.as_raw();
+        const COLOR_ATTACHMENT_WRITE = vk::AccessFlags2::COLOR_ATTACHMENT_WRITE.as_raw();
+        const DEPTH_STENCIL_ATTACHMENT_READ = vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_READ.as_raw();
+        const DEPTH_STENCIL_ATTACHMENT_WRITE = vk::AccessFlags2::DEPTH_STENCIL_ATTACHMENT_WRITE.as_raw();
+        const TRANSFER_READ = vk::AccessFlags2::TRANSFER_READ.as_raw();
+        const TRANSFER_WRITE = vk::AccessFlags2::TRANSFER_WRITE.as_raw();
+        const HOST_READ = vk::AccessFlags2::HOST_READ.as_raw();
+        const HOST_WRITE = vk::AccessFlags2::HOST_WRITE.as_raw();
+    }
+}
+unsafe impl Zeroable for Access {}
+unsafe impl Pod for Access {}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Stage: u64 {
+        const TOP_OF_PIPE = vk::PipelineStageFlags2::TOP_OF_PIPE.as_raw();
+        const DRAW_INDIRECT = vk::PipelineStageFlags2::DRAW_INDIRECT.as_raw();
+        const VERTEX_INPUT = vk::PipelineStageFlags2::VERTEX_INPUT.as_raw();
+        const VERTEX_SHADER = vk::PipelineStageFlags2::VERTEX_SHADER.as_raw();
+        const FRAGMENT_SHADER = vk::PipelineStageFlags2::FRAGMENT_SHADER.as_raw();
+        const COMPUTE_SHADER = vk::PipelineStageFlags2::COMPUTE_SHADER.as_raw();
+        const EARLY_FRAGMENT_TESTS = vk::PipelineStageFlags2::EARLY_FRAGMENT_TESTS.as_raw();
+        const LATE_FRAGMENT_TESTS = vk::PipelineStageFlags2::LATE_FRAGMENT_TESTS.as_raw();
+        const COLOR_ATTACHMENT_OUTPUT = vk::PipelineStageFlags2::COLOR_ATTACHMENT_OUTPUT.as_raw();
+        const TRANSFER = vk::PipelineStageFlags2::TRANSFER.as_raw();
+        const BOTTOM_OF_PIPE = vk::PipelineStageFlags2::BOTTOM_OF_PIPE.as_raw();
+    }
+}
+unsafe impl Zeroable for Stage {}
+unsafe impl Pod for Stage {}
+
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Pod, Zeroable, Default)]
+pub struct ImageLayout(pub i32);
+
+impl From<ImageLayout> for vk::ImageLayout {
+    fn from(layout: ImageLayout) -> Self {
+        vk::ImageLayout::from_raw(layout.0)
+    }
+}
+
+impl From<vk::ImageLayout> for ImageLayout {
+    fn from(layout: vk::ImageLayout) -> Self {
+        Self(layout.as_raw())
+    }
+}
+
+impl From<Access> for vk::AccessFlags2 {
+    fn from(acc: Access) -> Self {
+        vk::AccessFlags2::from_raw(acc.bits())
+    }
+}
+
+impl From<Stage> for vk::PipelineStageFlags2 {
+    fn from(stage: Stage) -> Self {
+        vk::PipelineStageFlags2::from_raw(stage.bits())
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, Pod, Zeroable)]
+pub struct ResState {
+    pub access: Access,
+    pub stages: Stage,
+    pub layout: ImageLayout,
+    pub _pad: u32,
+}


### PR DESCRIPTION
## Summary
- define Access, Stage, ImageLayout and ResState under sync module
- add BarrierBuilder to create image/buffer memory barriers and emit pipeline barrier only when needed
- allow Vulkan Context to look up raw handles for barriers

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae911076e0832ab862fb2cb50dd867