### PR TITLE
Add IR roundtrip test and compute-to-graphics example

### DIFF
--- a/examples/compute_to_graphics.rs
+++ b/examples/compute_to_graphics.rs
@@ -1,0 +1,80 @@
+use dashi::driver::command::{
+    BeginRenderPass, BindPipeline, BindTableCmd, BufferBarrier, ColorAttachment, CommandEncoder,
+    CommandSink, CopyBuffer, CopyImage, DebugMarkerBegin, DebugMarkerEnd, Dispatch, Draw,
+    EndRenderPass, ImageBarrier, LoadOp, RenderPassDesc, StoreOp,
+};
+use dashi::driver::state::SubresourceRange;
+use dashi::driver::types::{Handle, Pipeline};
+use dashi::Image;
+
+struct PrintSink;
+
+impl CommandSink for PrintSink {
+    fn begin_render_pass(&mut self, _: &BeginRenderPass) {
+        println!("begin_render_pass");
+    }
+    fn end_render_pass(&mut self, _: &EndRenderPass) {
+        println!("end_render_pass");
+    }
+    fn bind_pipeline(&mut self, _: &BindPipeline) {
+        println!("bind_pipeline");
+    }
+    fn bind_table(&mut self, _: &BindTableCmd) {
+        println!("bind_table");
+    }
+    fn draw(&mut self, _: &Draw) {
+        println!("draw");
+    }
+    fn dispatch(&mut self, _: &Dispatch) {
+        println!("dispatch");
+    }
+    fn copy_buffer(&mut self, _: &CopyBuffer) {
+        println!("copy_buffer");
+    }
+    fn copy_texture(&mut self, _: &CopyImage) {
+        println!("copy_texture");
+    }
+    fn texture_barrier(&mut self, _: &ImageBarrier) {
+        println!("texture_barrier");
+    }
+    fn buffer_barrier(&mut self, _: &BufferBarrier) {
+        println!("buffer_barrier");
+    }
+    fn debug_marker_begin(&mut self, _: &DebugMarkerBegin) {
+        println!("debug_marker_begin");
+    }
+    fn debug_marker_end(&mut self, _: &DebugMarkerEnd) {
+        println!("debug_marker_end");
+    }
+}
+
+fn main() {
+    let src = Handle::<Image>::new(1, 0);
+    let dst = Handle::<Image>::new(2, 0);
+    let range = SubresourceRange::new(0, 1, 0, 1);
+    let color = ColorAttachment {
+        handle: dst,
+        range,
+        clear: [0.0; 4],
+        load: LoadOp::Load,
+        store: StoreOp::Store,
+        _pad: [0; 2],
+    };
+
+    // Record commands using the IR encoder (acts like a secondary command buffer).
+    let mut enc = CommandEncoder::new();
+
+    // "Compute" step: copy data into the destination image.
+    enc.copy_texture(src, dst, range);
+
+    // "Graphics" step: render to the same image.
+    enc.begin_render_pass(RenderPassDesc { colors: &[color], depth: None });
+    enc.bind_pipeline(Handle::<Pipeline>::new(3, 0));
+    enc.draw(3, 1);
+    enc.end_render_pass();
+
+    // Replay on a sink to show the automatically inserted barriers.
+    let mut sink = PrintSink;
+    enc.submit(&mut sink);
+}
+

--- a/tests/ir_roundtrip.rs
+++ b/tests/ir_roundtrip.rs
@@ -1,0 +1,123 @@
+use dashi::driver::command::{
+    BeginRenderPass, BindPipeline, BindTableCmd, BufferBarrier, ColorAttachment, CommandEncoder,
+    CommandSink, CopyBuffer, CopyImage, DebugMarkerBegin, DebugMarkerEnd, Dispatch,
+    Draw, EndRenderPass, ImageBarrier, LoadOp, Op, RenderPassDesc, StoreOp,
+};
+use dashi::driver::state::SubresourceRange;
+use dashi::driver::types::{BindTable as BindTableRes, Handle, Pipeline};
+use dashi::{Buffer, Image};
+
+#[derive(Debug, PartialEq)]
+enum Recorded {
+    BeginRenderPass(BeginRenderPass),
+    EndRenderPass(EndRenderPass),
+    BindPipeline(BindPipeline),
+    BindTable(BindTableCmd),
+    Draw(Draw),
+    Dispatch(Dispatch),
+    CopyBuffer(CopyBuffer),
+    CopyImage(CopyImage),
+    ImageBarrier(ImageBarrier),
+    BufferBarrier(BufferBarrier),
+    DebugMarkerBegin(DebugMarkerBegin),
+    DebugMarkerEnd(DebugMarkerEnd),
+}
+
+#[derive(Default)]
+struct Recorder {
+    cmds: Vec<Recorded>,
+}
+
+impl CommandSink for Recorder {
+    fn begin_render_pass(&mut self, pass: &BeginRenderPass) {
+        self.cmds.push(Recorded::BeginRenderPass(*pass));
+    }
+    fn end_render_pass(&mut self, pass: &EndRenderPass) {
+        self.cmds.push(Recorded::EndRenderPass(*pass));
+    }
+    fn bind_pipeline(&mut self, cmd: &BindPipeline) {
+        self.cmds.push(Recorded::BindPipeline(*cmd));
+    }
+    fn bind_table(&mut self, cmd: &BindTableCmd) {
+        self.cmds.push(Recorded::BindTable(*cmd));
+    }
+    fn draw(&mut self, cmd: &Draw) {
+        self.cmds.push(Recorded::Draw(*cmd));
+    }
+    fn dispatch(&mut self, cmd: &Dispatch) {
+        self.cmds.push(Recorded::Dispatch(*cmd));
+    }
+    fn copy_buffer(&mut self, cmd: &CopyBuffer) {
+        self.cmds.push(Recorded::CopyBuffer(*cmd));
+    }
+    fn copy_texture(&mut self, cmd: &CopyImage) {
+        self.cmds.push(Recorded::CopyImage(*cmd));
+    }
+    fn texture_barrier(&mut self, cmd: &ImageBarrier) {
+        self.cmds.push(Recorded::ImageBarrier(*cmd));
+    }
+    fn buffer_barrier(&mut self, cmd: &BufferBarrier) {
+        self.cmds.push(Recorded::BufferBarrier(*cmd));
+    }
+    fn debug_marker_begin(&mut self, cmd: &DebugMarkerBegin) {
+        self.cmds.push(Recorded::DebugMarkerBegin(*cmd));
+    }
+    fn debug_marker_end(&mut self, cmd: &DebugMarkerEnd) {
+        self.cmds.push(Recorded::DebugMarkerEnd(*cmd));
+    }
+}
+
+#[test]
+fn ir_roundtrip_core_ops() {
+    let img_a = Handle::<Image>::new(1, 0);
+    let img_b = Handle::<Image>::new(2, 0);
+    let buf_a = Handle::<Buffer>::new(3, 0);
+    let buf_b = Handle::<Buffer>::new(4, 0);
+    let pipe = Handle::<Pipeline>::new(5, 0);
+    let table = Handle::<BindTableRes>::new(6, 0);
+    let range = SubresourceRange::new(0, 1, 0, 1);
+
+    let color = ColorAttachment {
+        handle: img_b,
+        range,
+        clear: [0.0; 4],
+        load: LoadOp::Load,
+        store: StoreOp::Store,
+        _pad: [0; 2],
+    };
+
+    let mut enc = CommandEncoder::new();
+    enc.begin_debug_marker();
+    enc.copy_texture(img_a, img_b, range);
+    enc.begin_render_pass(RenderPassDesc { colors: &[color], depth: None });
+    enc.bind_pipeline(pipe);
+    enc.bind_table(table);
+    enc.draw(3, 1);
+    enc.end_render_pass();
+    enc.dispatch(1, 2, 3);
+    enc.copy_buffer(buf_a, buf_b);
+    enc.end_debug_marker();
+
+    let expected: Vec<Recorded> = enc
+        .iter()
+        .map(|c| match c.op {
+            Op::BeginRenderPass => Recorded::BeginRenderPass(*c.payload()),
+            Op::EndRenderPass => Recorded::EndRenderPass(*c.payload()),
+            Op::BindPipeline => Recorded::BindPipeline(*c.payload()),
+            Op::BindTable => Recorded::BindTable(*c.payload()),
+            Op::Draw => Recorded::Draw(*c.payload()),
+            Op::Dispatch => Recorded::Dispatch(*c.payload()),
+            Op::CopyBuffer => Recorded::CopyBuffer(*c.payload()),
+            Op::CopyImage => Recorded::CopyImage(*c.payload()),
+            Op::ImageBarrier => Recorded::ImageBarrier(*c.payload()),
+            Op::BufferBarrier => Recorded::BufferBarrier(*c.payload()),
+            Op::DebugMarkerBegin => Recorded::DebugMarkerBegin(*c.payload()),
+            Op::DebugMarkerEnd => Recorded::DebugMarkerEnd(*c.payload()),
+        })
+        .collect();
+
+    let mut recorder = Recorder::default();
+    enc.submit(&mut recorder);
+    assert_eq!(expected, recorder.cmds);
+}
+


### PR DESCRIPTION
## Summary
- add IR encoder roundtrip unit test for core commands
- document secondary command buffers with compute-to-graphics example

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b1fb3cfea8832a92f3c2adfb9a23cb