### PR TITLE
Add null IR replayer and test roundtrip

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,3 +1,5 @@
 pub mod replay_vk;
+pub mod replay_null;
 
 pub use replay_vk::VkReplayer;
+pub use replay_null::NullReplayer;

--- a/src/ir/replay_null.rs
+++ b/src/ir/replay_null.rs
@@ -1,0 +1,62 @@
+use crate::driver::command::{
+    BeginRenderPass, BindPipeline, BindTableCmd, BufferBarrier, CommandEncoder, CommandSink,
+    CopyBuffer, CopyImage, DebugMarkerBegin, DebugMarkerEnd, Dispatch, Draw, EndRenderPass,
+    ImageBarrier, Op as OpTag,
+};
+
+/// Replays an encoded command stream on any [`CommandSink`].
+///
+/// This is useful for tests or headless backends where commands are
+/// interpreted without performing real GPU work.
+pub struct NullReplayer<'a, S: CommandSink> {
+    sink: &'a mut S,
+}
+
+impl<'a, S: CommandSink> NullReplayer<'a, S> {
+    /// Create a new replayer targeting the given sink.
+    pub fn new(sink: &'a mut S) -> Self {
+        Self { sink }
+    }
+
+    /// Iterate over the encoded command stream and forward each operation to
+    /// the underlying sink.
+    pub fn replay(&mut self, encoder: &CommandEncoder) {
+        for cmd in encoder.iter() {
+            match cmd.op {
+                OpTag::BeginRenderPass => {
+                    CommandSink::begin_render_pass(self.sink, cmd.payload::<BeginRenderPass>())
+                }
+                OpTag::EndRenderPass => {
+                    CommandSink::end_render_pass(self.sink, cmd.payload::<EndRenderPass>())
+                }
+                OpTag::BindPipeline => {
+                    CommandSink::bind_pipeline(self.sink, cmd.payload::<BindPipeline>())
+                }
+                OpTag::BindTable => {
+                    CommandSink::bind_table(self.sink, cmd.payload::<BindTableCmd>())
+                }
+                OpTag::Draw => CommandSink::draw(self.sink, cmd.payload::<Draw>()),
+                OpTag::Dispatch => CommandSink::dispatch(self.sink, cmd.payload::<Dispatch>()),
+                OpTag::CopyBuffer => {
+                    CommandSink::copy_buffer(self.sink, cmd.payload::<CopyBuffer>())
+                }
+                OpTag::CopyImage => {
+                    CommandSink::copy_texture(self.sink, cmd.payload::<CopyImage>())
+                }
+                OpTag::ImageBarrier => {
+                    CommandSink::texture_barrier(self.sink, cmd.payload::<ImageBarrier>())
+                }
+                OpTag::BufferBarrier => {
+                    CommandSink::buffer_barrier(self.sink, cmd.payload::<BufferBarrier>())
+                }
+                OpTag::DebugMarkerBegin => {
+                    CommandSink::debug_marker_begin(self.sink, cmd.payload::<DebugMarkerBegin>())
+                }
+                OpTag::DebugMarkerEnd => {
+                    CommandSink::debug_marker_end(self.sink, cmd.payload::<DebugMarkerEnd>())
+                }
+            }
+        }
+    }
+}
+

--- a/tests/ir_roundtrip.rs
+++ b/tests/ir_roundtrip.rs
@@ -6,6 +6,7 @@ use dashi::driver::command::{
 use dashi::driver::state::SubresourceRange;
 use dashi::driver::types::{BindTable as BindTableRes, Handle, Pipeline};
 use dashi::{Buffer, Image};
+use dashi::ir::NullReplayer;
 
 #[derive(Debug, PartialEq)]
 enum Recorded {
@@ -117,7 +118,8 @@ fn ir_roundtrip_core_ops() {
         .collect();
 
     let mut recorder = Recorder::default();
-    enc.submit(&mut recorder);
+    let mut replayer = NullReplayer::new(&mut recorder);
+    replayer.replay(&enc);
     assert_eq!(expected, recorder.cmds);
 }
 


### PR DESCRIPTION
## Summary
- add null replayer that dispatches IR commands to any `CommandSink`
- export the new replayer alongside the Vulkan backend
- cover null backend in IR roundtrip test

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b20ca2ec2c832aa66b7640129629bc