### PR TITLE
Refactor FramedCommandList context handling and error APIs

### DIFF
--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -261,7 +261,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3).unwrap();
     let sems = ctx.make_semaphores(2).unwrap();
     'running: loop {
         // Reset the allocator
@@ -339,14 +339,17 @@ void main() {
                 filter: Filter::Nearest,
                 ..Default::default()
             });
-        });
+        })
+        .unwrap();
 
         // Submit our recorded commands
-        framed_list.submit(&SubmitInfo {
-            wait_sems: &[sem],
-            signal_sems: &[sems[0], sems[1]],
-            ..Default::default()
-        });
+        framed_list
+            .submit(&SubmitInfo {
+                wait_sems: &[sem],
+                signal_sems: &[sems[0], sems[1]],
+                ..Default::default()
+            })
+            .unwrap();
 
         // Present the display image, waiting on the semaphore that will signal when our
         // drawing/blitting is done.

--- a/examples/minifb_triangle.rs
+++ b/examples/minifb_triangle.rs
@@ -272,7 +272,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3).unwrap();
     let sems = ctx.make_semaphores(2).unwrap();
     'running: while display.minifb_window().is_open() {
         // Reset the allocator
@@ -334,14 +334,17 @@ void main() {
                 filter: Filter::Nearest,
                 ..Default::default()
             });
-        });
+        })
+        .unwrap();
 
         // Submit our recorded commands
-        framed_list.submit(&SubmitInfo {
-            wait_sems: &[sem],
-            signal_sems: &[sems[0], sems[1]],
-            ..Default::default()
-        });
+        framed_list
+            .submit(&SubmitInfo {
+                wait_sems: &[sem],
+                signal_sems: &[sems[0], sems[1]],
+                ..Default::default()
+            })
+            .unwrap();
 
         // Present the display image, waiting on the semaphore that will signal when our
         // drawing/blitting is done.

--- a/examples/openxr_simple_scene.rs
+++ b/examples/openxr_simple_scene.rs
@@ -210,7 +210,7 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
 
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2).unwrap();
 
     for _ in 0..100 {
         allocator.reset();
@@ -248,8 +248,8 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
                 ..Default::default()
             }));
             list.end_drawing().unwrap();
-        });
-        framed_list.submit(&SubmitInfo::default());
+        }).unwrap();
+        framed_list.submit(&SubmitInfo::default()).unwrap();
         ctx.present_xr_display(&mut display, state).unwrap();
     }
 }

--- a/examples/openxr_triangle.rs
+++ b/examples/openxr_triangle.rs
@@ -192,7 +192,7 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
 
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2).unwrap();
 
     for _ in 0..100 {
         allocator.reset();
@@ -222,8 +222,8 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
                 ..Default::default()
             }));
             list.end_drawing().unwrap();
-        });
-        framed_list.submit(&SubmitInfo::default());
+        }).unwrap();
+        framed_list.submit(&SubmitInfo::default()).unwrap();
         ctx.present_xr_display(&mut display, state).unwrap();
     }
 }

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -264,7 +264,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3).unwrap();
     let sems = ctx.make_semaphores(2).unwrap();
     'running: loop {
         // Reset the allocator
@@ -342,14 +342,17 @@ void main() {
                 filter: Filter::Nearest,
                 ..Default::default()
             });
-        });
+        })
+        .unwrap();
 
         // Submit our recorded commands
-        framed_list.submit(&SubmitInfo {
-            wait_sems: &[sem],
-            signal_sems: &[sems[0], sems[1]],
-            ..Default::default()
-        });
+        framed_list
+            .submit(&SubmitInfo {
+                wait_sems: &[sem],
+                signal_sems: &[sems[0], sems[1]],
+                ..Default::default()
+            })
+            .unwrap();
 
         // Present the display image, waiting on the semaphore that will signal when our
         // drawing/blitting is done.

--- a/tests/minifb_triangle.rs
+++ b/tests/minifb_triangle.rs
@@ -268,7 +268,7 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3);
+    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3).unwrap();
     let sems = ctx.make_semaphores(2).unwrap();
     'running: while display.minifb_window().is_open() {
         // Reset the allocator
@@ -330,14 +330,17 @@ void main() {
                 filter: Filter::Nearest,
                 ..Default::default()
             });
-        });
+        })
+        .unwrap();
 
         // Submit our recorded commands
-        framed_list.submit(&SubmitInfo {
-            wait_sems: &[sem],
-            signal_sems: &[sems[0], sems[1]],
-            ..Default::default()
-        });
+        framed_list
+            .submit(&SubmitInfo {
+                wait_sems: &[sem],
+                signal_sems: &[sems[0], sems[1]],
+                ..Default::default()
+            })
+            .unwrap();
 
         // Present the display image, waiting on the semaphore that will signal when our
         // drawing/blitting is done.

--- a/tests/openxr_triangle.rs
+++ b/tests/openxr_triangle.rs
@@ -115,7 +115,7 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
     let bind_group = ctx.make_bind_group(&BindGroupInfo{debug_name:"OpenXR Triangle",layout:bg_layout,bindings:&[BindingInfo{resource:ShaderResource::Dynamic(&allocator),binding:0}],..Default::default()}).unwrap();
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx,"Default",2);
+    let mut framed_list = FramedCommandList::new(&mut ctx,"Default",2).unwrap();
     allocator.reset();
     let (_idx,state) = ctx.acquire_xr_image(&mut display).unwrap();
     framed_list.record(|list|{
@@ -131,8 +131,8 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
         pos[1]=(timer.elapsed_ms() as f32/1000.0).cos();
         list.append(Command::DrawIndexed(DrawIndexed{vertices,indices,index_count:INDICES.len() as u32,bind_groups:[Some(bind_group),None,None,None],dynamic_buffers:[Some(buf),None,None,None],..Default::default()}));
         list.end_drawing().unwrap();
-    });
-    framed_list.submit(&SubmitInfo::default());
+    }).unwrap();
+    framed_list.submit(&SubmitInfo::default()).unwrap();
     ctx.present_xr_display(&mut display,state).unwrap();
 }
 


### PR DESCRIPTION
## Summary
- switch `FramedCommandList` to use `NonNull<Context>` instead of a raw pointer
- return `Result` from all public `FramedCommandList` methods and propagate errors
- fix frame advancement logic to use `self.cmds.len()`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b2662ba49c832a8cb87e555cdeda3a