### PR TITLE
Refactor bindings management

### DIFF
--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -324,8 +324,11 @@ void main() {
                 vertices,
                 indices,
                 index_count: INDICES.len() as u32,
-                bind_groups: [Some(bind_group), None, None, None],
-                dynamic_buffers: [Some(buf), None, None, None],
+                bindings: Bindings {
+                    bind_groups: [Some(bind_group), None, None, None],
+                    dynamic_buffers: [Some(buf), None, None, None],
+                    ..Default::default()
+                },
                 ..Default::default()
             }));
 

--- a/examples/minifb_triangle.rs
+++ b/examples/minifb_triangle.rs
@@ -319,8 +319,11 @@ void main() {
                 vertices,
                 indices,
                 index_count: INDICES.len() as u32,
-                bind_groups: [Some(bind_group), None, None, None],
-                dynamic_buffers: [Some(buf), None, None, None],
+                bindings: Bindings {
+                    bind_groups: [Some(bind_group), None, None, None],
+                    dynamic_buffers: [Some(buf), None, None, None],
+                    ..Default::default()
+                },
                 ..Default::default()
             }));
 

--- a/examples/openxr_simple_scene.rs
+++ b/examples/openxr_simple_scene.rs
@@ -243,8 +243,11 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
                 vertices,
                 indices,
                 index_count: INDICES.len() as u32,
-                bind_groups: [Some(bind_group), None, None, None],
-                dynamic_buffers: [Some(buf), None, None, None],
+                bindings: Bindings {
+                    bind_groups: [Some(bind_group), None, None, None],
+                    dynamic_buffers: [Some(buf), None, None, None],
+                    ..Default::default()
+                },
                 ..Default::default()
             }));
             list.end_drawing().unwrap();

--- a/examples/openxr_triangle.rs
+++ b/examples/openxr_triangle.rs
@@ -217,8 +217,11 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
                 vertices,
                 indices,
                 index_count: INDICES.len() as u32,
-                bind_groups: [Some(bind_group), None, None, None],
-                dynamic_buffers: [Some(buf), None, None, None],
+                bindings: Bindings {
+                    bind_groups: [Some(bind_group), None, None, None],
+                    dynamic_buffers: [Some(buf), None, None, None],
+                    ..Default::default()
+                },
                 ..Default::default()
             }));
             list.end_drawing().unwrap();

--- a/src/gpu/vulkan/mod.rs
+++ b/src/gpu/vulkan/mod.rs
@@ -3403,8 +3403,11 @@ void main() {
         list.dispatch_compute(Dispatch {
             compute: pipeline,
             workgroup_size: [BUFF_SIZE / std::mem::size_of::<f32>() as u32, 1, 1],
-            bind_groups: [Some(bind_group), None, None, None],
-            dynamic_buffers: [Some(buf), None, None, None],
+            bindings: Bindings {
+                bind_groups: [Some(bind_group), None, None, None],
+                dynamic_buffers: [Some(buf), None, None, None],
+                ..Default::default()
+            },
             ..Default::default()
         });
 

--- a/tests/compute_then_graphics.rs
+++ b/tests/compute_then_graphics.rs
@@ -166,7 +166,10 @@ void main(){ out_color = buf.color; }
         list.dispatch_compute(Dispatch {
             compute: comp_pipe,
             workgroup_size: [1,1,1],
-            bind_groups: [Some(bind_group), None, None, None],
+            bindings: Bindings {
+                bind_groups: [Some(bind_group), None, None, None],
+                ..Default::default()
+            },
             ..Default::default()
         });
         let fence = ctx.submit(&mut list, &Default::default()).unwrap();
@@ -207,7 +210,15 @@ void main(){ out_color = buf.color; }
             render_target: rt,
             clear_values: &[ClearValue::Color([0.0,0.0,0.0,1.0])],
         }).unwrap();
-        list.append(Command::Draw(Draw { vertices: vb, count: 3, bind_groups: [Some(bind_group), None, None, None], ..Default::default() }));
+        list.append(Command::Draw(Draw {
+            vertices: vb,
+            count: 3,
+            bindings: Bindings {
+                bind_groups: [Some(bind_group), None, None, None],
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
         list.end_drawing().unwrap();
         let fence = ctx.submit(&mut list, &Default::default()).unwrap();
         ctx.wait(fence).unwrap();

--- a/tests/hello_bindless/bin.rs
+++ b/tests/hello_bindless/bin.rs
@@ -87,8 +87,11 @@ fn main() {
     list.dispatch_compute(Dispatch {
         compute: pipeline,
         workgroup_size: [1, 1, 1],
-        bind_tables: [Some(table), None, None, None],
-        dynamic_buffers: [Some(buf), None, None, None],
+        bindings: Bindings {
+            bind_tables: [Some(table), None, None, None],
+            dynamic_buffers: [Some(buf), None, None, None],
+            ..Default::default()
+        },
         ..Default::default()
     });
     let fence = ctx.submit(&mut list, &Default::default()).unwrap();

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -327,8 +327,11 @@ void main() {
                 vertices,
                 indices,
                 index_count: INDICES.len() as u32,
-                bind_groups: [Some(bind_group), None, None, None],
-                dynamic_buffers: [Some(buf), None, None, None],
+                bindings: Bindings {
+                    bind_groups: [Some(bind_group), None, None, None],
+                    dynamic_buffers: [Some(buf), None, None, None],
+                    ..Default::default()
+                },
                 ..Default::default()
             }));
 

--- a/tests/minifb_triangle.rs
+++ b/tests/minifb_triangle.rs
@@ -315,8 +315,11 @@ void main() {
                 vertices,
                 indices,
                 index_count: INDICES.len() as u32,
-                bind_groups: [Some(bind_group), None, None, None],
-                dynamic_buffers: [Some(buf), None, None, None],
+                bindings: Bindings {
+                    bind_groups: [Some(bind_group), None, None, None],
+                    dynamic_buffers: [Some(buf), None, None, None],
+                    ..Default::default()
+                },
                 ..Default::default()
             }));
 

--- a/tests/openxr_triangle.rs
+++ b/tests/openxr_triangle.rs
@@ -129,7 +129,17 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
         let pos=&mut buf.slice::<[f32;2]>()[0];
         pos[0]=(timer.elapsed_ms() as f32/1000.0).sin();
         pos[1]=(timer.elapsed_ms() as f32/1000.0).cos();
-        list.append(Command::DrawIndexed(DrawIndexed{vertices,indices,index_count:INDICES.len() as u32,bind_groups:[Some(bind_group),None,None,None],dynamic_buffers:[Some(buf),None,None,None],..Default::default()}));
+        list.append(Command::DrawIndexed(DrawIndexed{
+            vertices,
+            indices,
+            index_count: INDICES.len() as u32,
+            bindings: Bindings {
+                bind_groups: [Some(bind_group), None, None, None],
+                dynamic_buffers: [Some(buf), None, None, None],
+                ..Default::default()
+            },
+            ..Default::default()
+        }));
         list.end_drawing().unwrap();
     }).unwrap();
     framed_list.submit(&SubmitInfo::default()).unwrap();


### PR DESCRIPTION
## Summary
- add shared `Bindings` struct for bind groups, tables, and dynamic buffers
- iterate over bindings and dynamic offsets to simplify encoding
- update examples and tests to use unified bindings

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b278cf7bfc832aa8f0687bfcb13cf3