### PR TITLE
Handle Vulkan TODOs with GPUError

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ is mutually exclusive with them.
 
 Detailed documentation is available [here](https://github.com/JordanHendl/dashi/wiki). It includes guides, API references, and examples to help you get the most out of Dashi.
 
+## Unimplemented Features
+
+- Constant buffer bindings in bind groups and bind tables are not yet supported.
+- Graphics pipeline layouts only accept vertex and fragment stages; other stages return an error.
+- Only a limited set of Vulkan image formats is supported; unsupported formats will produce a `GPUError`.
+
 ## Roadmap
 
 - [x] Vulkan backend support

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -1432,12 +1432,22 @@ impl CommandList {
         }
      }
  
-     fn debug_marker_begin(&mut self, _cmd: &crate::driver::command::DebugMarkerBegin) {
+    fn debug_marker_begin(&mut self, _cmd: &crate::driver::command::DebugMarkerBegin) {
         // Debug markers are not directly supported in Vulkan, so we need to use a memory barrier
         unsafe { self.ctx_ref().device.cmd_pipeline_barrier(self.cmd_buf, vk::PipelineStageFlags::ALL_COMMANDS, vk::PipelineStageFlags::ALL_COMMANDS, vk::DependencyFlags::empty(), &[], &[], &[]) };
-     }
+    }
 
     fn debug_marker_end(&mut self, _cmd: &crate::driver::command::DebugMarkerEnd) {
-        todo!()
+        unsafe {
+            self.ctx_ref().device.cmd_pipeline_barrier(
+                self.cmd_buf,
+                vk::PipelineStageFlags::ALL_COMMANDS,
+                vk::PipelineStageFlags::ALL_COMMANDS,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                &[],
+            )
+        };
     }
- }
+}

--- a/src/gpu/vulkan/conversions.rs
+++ b/src/gpu/vulkan/conversions.rs
@@ -1,7 +1,7 @@
 use ash::vk;
 use crate::{
     AspectMask, BarrierPoint, BlendFactor, BlendOp, BorderColor, ColorBlendState, DynamicState,
-    Filter, Format, LoadOp, Rect2D, SampleCount, SamplerAddressMode, SamplerInfo,
+    Filter, Format, GPUError, LoadOp, Rect2D, SampleCount, SamplerAddressMode, SamplerInfo,
     SamplerMipmapMode, StoreOp, WriteMask,
 };
 
@@ -177,16 +177,16 @@ pub(super) fn lib_to_vk_image_format(fmt: &Format) -> vk::Format {
     }
 }
 
-pub(super) fn vk_to_lib_image_format(fmt: vk::Format) -> Format {
+pub(super) fn vk_to_lib_image_format(fmt: vk::Format) -> Result<Format, GPUError> {
     match fmt {
-        vk::Format::R8G8B8_SRGB => Format::RGB8,
-        vk::Format::R32G32B32A32_SFLOAT => Format::RGBA32F,
-        vk::Format::R8G8B8A8_SRGB => Format::RGBA8,
-        vk::Format::B8G8R8A8_SRGB => Format::BGRA8,
-        vk::Format::B8G8R8A8_SNORM => Format::BGRA8Unorm,
-        vk::Format::R8_SINT => Format::R8Sint,
-        vk::Format::R8_UINT => Format::R8Uint,
-        _ => todo!(),
+        vk::Format::R8G8B8_SRGB => Ok(Format::RGB8),
+        vk::Format::R32G32B32A32_SFLOAT => Ok(Format::RGBA32F),
+        vk::Format::R8G8B8A8_SRGB => Ok(Format::RGBA8),
+        vk::Format::B8G8R8A8_SRGB => Ok(Format::BGRA8),
+        vk::Format::B8G8R8A8_SNORM => Ok(Format::BGRA8Unorm),
+        vk::Format::R8_SINT => Ok(Format::R8Sint),
+        vk::Format::R8_UINT => Ok(Format::R8Uint),
+        other => Err(GPUError::UnsupportedFormat(other)),
     }
 }
 

--- a/src/gpu/vulkan/display.rs
+++ b/src/gpu/vulkan/display.rs
@@ -306,7 +306,7 @@ impl Context {
                     .aspect_mask(vk::ImageAspectFlags::COLOR)
                     .build(),
                 dim: [chosen_extent.width, chosen_extent.height, 1],
-                format: super::vk_to_lib_image_format(wanted_format),
+                format: super::vk_to_lib_image_format(wanted_format)?,
             }) {
                 Some(handle) => {
                     self.oneshot_transition_image_noview(
@@ -335,7 +335,7 @@ impl Context {
                     view_handles.push(h);
                     handles.push(handle)
                 }
-                None => todo!(),
+                None => return Err(GPUError::SlotError()),
             };
         }
 

--- a/src/gpu/vulkan/error.rs
+++ b/src/gpu/vulkan/error.rs
@@ -1,4 +1,7 @@
 use std::fmt;
+use ash::vk;
+use super::structs::ShaderType;
+
 #[derive(Debug)]
 pub struct VulkanError {
     res: ash::vk::Result,
@@ -25,6 +28,9 @@ pub enum GPUError {
     LibraryError(),
     SlotError(),
     HeadlessDisplayNotSupported,
+    UnsupportedFormat(vk::Format),
+    UnsupportedShaderStage(ShaderType),
+    Unimplemented(&'static str),
 }
 
 /// Convenient crate-wide result type.


### PR DESCRIPTION
## Summary
- return GPUError for unsupported Vulkan formats and shader stages
- implement debug marker end stub and replace todo! calls in descriptor updates
- document currently unimplemented features in README

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b278d475ac832aa81616672f28bf06