### PR TITLE
Encode pipeline binding at type level

### DIFF
--- a/src/gfx/mod.rs
+++ b/src/gfx/mod.rs
@@ -1,3 +1,14 @@
 pub mod cmd;
 
-pub use cmd::{CommandBuffer, CommandBuilder, CommandBuilderExt, RenderScope, DebugLabelScope, EncodeTarget};
+pub use cmd::{
+    CommandBuffer,
+    CommandBuilder,
+    CommandBuilderExt,
+    DebugLabelScope,
+    EncodeTarget,
+    PipelineBound,
+    PipelineBuilder,
+    RenderScope,
+    DescriptorWriteBuilder,
+    DynamicRenderingBuilder,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,18 @@ pub mod gfx;
 pub mod framegraph;
 
 pub use driver::types::{Handle, IndexType, UsageBits};
-pub use gfx::cmd::{CommandBuffer, CommandBuilder, CommandBuilderExt, RenderScope, DebugLabelScope, EncodeTarget};
+pub use gfx::cmd::{
+    CommandBuffer,
+    CommandBuilder,
+    CommandBuilderExt,
+    DebugLabelScope,
+    EncodeTarget,
+    PipelineBound,
+    PipelineBuilder,
+    RenderScope,
+    DescriptorWriteBuilder,
+    DynamicRenderingBuilder,
+};
 
 pub mod gpu;
 #[cfg(feature = "dx12")]


### PR DESCRIPTION
## Summary
- add `PipelineBound` marker for command buffers
- allow `draw` only when a pipeline is bound
- drop thread-local pipeline tracking

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b278cdd5c8832a9cce4803f663776b