### PR TITLE
Add backend trait with buffer creation and submission

### DIFF
--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -92,7 +92,7 @@ fn main() {
 
     // Allocate the vertices & indices.
     let vertices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vertices",
             byte_size: (VERTICES.len() * std::mem::size_of::<f32>() * 2) as u32,
             visibility: MemoryVisibility::Gpu,
@@ -102,7 +102,7 @@ fn main() {
         .unwrap();
 
     let indices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "indices",
             byte_size: (INDICES.len() * std::mem::size_of::<u32>()) as u32,
             visibility: MemoryVisibility::Gpu,

--- a/examples/minifb_triangle.rs
+++ b/examples/minifb_triangle.rs
@@ -102,7 +102,7 @@ fn main() {
 
     // Allocate the vertices & indices.
     let vertices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vertices",
             byte_size: (VERTICES.len() * std::mem::size_of::<f32>() * 2) as u32,
             visibility: MemoryVisibility::Gpu,
@@ -112,7 +112,7 @@ fn main() {
         .unwrap();
 
     let indices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "indices",
             byte_size: (INDICES.len() * std::mem::size_of::<u32>()) as u32,
             visibility: MemoryVisibility::Gpu,

--- a/examples/openxr_simple_scene.rs
+++ b/examples/openxr_simple_scene.rs
@@ -83,7 +83,7 @@ fn main() {
     const INDICES: [u32; 3] = [0, 1, 2];
 
     let vertices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vertices",
             byte_size: (VERTICES.len() * std::mem::size_of::<f32>() * 3) as u32,
             visibility: MemoryVisibility::Gpu,
@@ -93,7 +93,7 @@ fn main() {
         .unwrap();
 
     let indices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "indices",
             byte_size: (INDICES.len() * std::mem::size_of::<u32>()) as u32,
             visibility: MemoryVisibility::Gpu,

--- a/examples/openxr_triangle.rs
+++ b/examples/openxr_triangle.rs
@@ -62,7 +62,7 @@ fn main() {
     const INDICES: [u32; 3] = [0, 1, 2];
 
     let vertices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vertices",
             byte_size: (VERTICES.len() * std::mem::size_of::<f32>() * 2) as u32,
             visibility: MemoryVisibility::Gpu,
@@ -72,7 +72,7 @@ fn main() {
         .unwrap();
 
     let indices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "indices",
             byte_size: (INDICES.len() * std::mem::size_of::<u32>()) as u32,
             visibility: MemoryVisibility::Gpu,

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,5 +1,35 @@
+use crate::Handle;
+
+/// Abstraction over GPU backends.
+///
+/// Each backend implements this trait on its context type, allowing code to be
+/// written generically over the supported graphics APIs.
 pub trait Backend {
-    type Context;
+    /// Backend-specific description of a buffer to create.
+    type BufferInfo<'a>;
+    /// Raw buffer handle returned by the backend.
+    type Buffer;
+    /// Command list type used for submissions.
+    type CommandList;
+    /// Parameters controlling how work is submitted to the GPU.
+    type SubmitInfo<'a>;
+    /// Fence handle returned from submissions for synchronization.
+    type Fence;
+    /// Error type produced by the backend.
+    type Error;
+
+    /// Create a GPU buffer with the provided description.
+    fn create_buffer<'a>(
+        &mut self,
+        info: &Self::BufferInfo<'a>,
+    ) -> std::result::Result<Handle<Self::Buffer>, Self::Error>;
+
+    /// Submit a command list for execution.
+    fn submit<'a>(
+        &mut self,
+        cmd: &mut Self::CommandList,
+        info: &Self::SubmitInfo<'a>,
+    ) -> std::result::Result<Handle<Self::Fence>, Self::Error>;
 }
 
 #[cfg(feature = "vulkan")]

--- a/src/utils/gpupool.rs
+++ b/src/utils/gpupool.rs
@@ -28,11 +28,11 @@ impl<T> GPUPool<T> {
         let mut b = info.clone();
         let staging_name = format!("{} Staging Buffer", info.debug_name);
         b.visibility = MemoryVisibility::Gpu;
-        let buffer = ctx.make_buffer(&b)?;
+        let buffer = ctx.create_buffer(&b)?;
 
         b.debug_name = &staging_name;
         b.visibility = MemoryVisibility::CpuAndGpu;
-        let staging = ctx.make_buffer(&b)?;
+        let staging = ctx.create_buffer(&b)?;
 
         let mapped = ctx.map_buffer_mut::<u8>(staging)?;
         let pool = Pool::new_preallocated(mapped.as_mut_ptr(), len);

--- a/tests/compute_then_graphics.rs
+++ b/tests/compute_then_graphics.rs
@@ -14,7 +14,7 @@ fn compute_then_graphics() {
 
     // buffer that compute pass writes color into and graphics pass reads from
     let color_buf = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "color_buf",
             byte_size: 16,
             visibility: MemoryVisibility::Gpu,
@@ -136,7 +136,7 @@ void main(){ out_color = buf.color; }
 
     // vertex buffer for fullscreen triangle (not actually used but required)
     let vb = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vb",
             byte_size: 4,
             visibility: MemoryVisibility::Gpu,
@@ -232,7 +232,7 @@ void main(){ out_color = buf.color; }
 
     // read back image and save
     let readback = ctx
-        .make_buffer(&BufferInfo { debug_name: "readback", byte_size: (WIDTH*HEIGHT*4) as u32, visibility: MemoryVisibility::CpuAndGpu, ..Default::default() })
+        .create_buffer(&BufferInfo { debug_name: "readback", byte_size: (WIDTH*HEIGHT*4) as u32, visibility: MemoryVisibility::CpuAndGpu, ..Default::default() })
         .unwrap();
     let mut list = ctx.begin_command_list(&Default::default()).unwrap();
     list.copy_image_to_buffer(ImageBufferCopy { src: view, dst: readback, dst_offset: 0 });

--- a/tests/framebuffer_compare.rs
+++ b/tests/framebuffer_compare.rs
@@ -26,7 +26,7 @@ fn framebuffer_compare() {
     let view = ImageView { img: image, ..Default::default() };
 
     let buffer = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "readback",
             byte_size: (width * height * 4) as u32,
             visibility: MemoryVisibility::CpuAndGpu,

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -95,7 +95,7 @@ fn main() {
 
     // Allocate the vertices & indices.
     let vertices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vertices",
             byte_size: (VERTICES.len() * std::mem::size_of::<f32>() * 2) as u32,
             visibility: MemoryVisibility::Gpu,
@@ -105,7 +105,7 @@ fn main() {
         .unwrap();
 
     let indices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "indices",
             byte_size: (INDICES.len() * std::mem::size_of::<u32>()) as u32,
             visibility: MemoryVisibility::Gpu,

--- a/tests/minifb_triangle.rs
+++ b/tests/minifb_triangle.rs
@@ -99,7 +99,7 @@ fn minifb_triangle() {
 
     // Allocate the vertices & indices.
     let vertices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vertices",
             byte_size: (VERTICES.len() * std::mem::size_of::<f32>() * 2) as u32,
             visibility: MemoryVisibility::Gpu,
@@ -109,7 +109,7 @@ fn minifb_triangle() {
         .unwrap();
 
     let indices = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "indices",
             byte_size: (INDICES.len() * std::mem::size_of::<u32>()) as u32,
             visibility: MemoryVisibility::Gpu,

--- a/tests/mipmap_generation.rs
+++ b/tests/mipmap_generation.rs
@@ -28,7 +28,7 @@ fn mipmap_generation() {
     };
 
     let buffer = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "readback",
             byte_size: 4,
             visibility: MemoryVisibility::CpuAndGpu,

--- a/tests/openxr_triangle.rs
+++ b/tests/openxr_triangle.rs
@@ -44,14 +44,14 @@ fn openxr_triangle() {
 
     const VERTICES: [[f32; 2]; 3] = [[0.0, -0.5],[0.5, 0.5],[-0.5, 0.5]];
     const INDICES: [u32; 3] = [0,1,2];
-    let vertices = ctx.make_buffer(&BufferInfo{
+    let vertices = ctx.create_buffer(&BufferInfo{
         debug_name:"vertices",
         byte_size:(VERTICES.len()*std::mem::size_of::<f32>()*2) as u32,
         visibility:MemoryVisibility::Gpu,
         usage:BufferUsage::VERTEX,
         initial_data:unsafe{Some(VERTICES.align_to::<u8>().1)}
     }).unwrap();
-    let indices = ctx.make_buffer(&BufferInfo{
+    let indices = ctx.create_buffer(&BufferInfo{
         debug_name:"indices",
         byte_size:(INDICES.len()*std::mem::size_of::<u32>()) as u32,
         visibility:MemoryVisibility::Gpu,

--- a/tests/pipeline_switch.rs
+++ b/tests/pipeline_switch.rs
@@ -108,7 +108,7 @@ fn pipeline_switch() {
         .unwrap();
 
     let vb = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "vb",
             byte_size: 4,
             visibility: MemoryVisibility::Gpu,

--- a/tests/vulkan_api.rs
+++ b/tests/vulkan_api.rs
@@ -17,7 +17,7 @@ fn test_buffer() {
     let mut ctx = Context::headless(&Default::default()).unwrap();
 
     let initial_data = vec![c_test_val as u8; c_buffer_size as usize];
-    let buffer_res = ctx.make_buffer(&BufferInfo {
+    let buffer_res = ctx.create_buffer(&BufferInfo {
         debug_name: "Test Buffer",
         byte_size: c_buffer_size,
         visibility: MemoryVisibility::CpuAndGpu,
@@ -88,13 +88,13 @@ fn test_headless_context_creation() {
 
     // Core Vulkan ops still work:
     let buf = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "headless-buffer",
             byte_size: 128,
             visibility: MemoryVisibility::CpuAndGpu,
             ..Default::default()
         })
-        .expect("make_buffer failed in headless mode");
+        .expect("create_buffer failed in headless mode");
     ctx.destroy_buffer(buf);
 
     // And we can clean up without panicking
@@ -213,7 +213,7 @@ outputData[index] = inputData[index] + num_to_add;
     const BUFF_SIZE: u32 = 2048 * std::mem::size_of::<f32>() as u32;
     let initial_data = vec![0; BUFF_SIZE as usize];
     let input = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "input_test",
             byte_size: BUFF_SIZE,
             visibility: MemoryVisibility::Gpu,
@@ -223,7 +223,7 @@ outputData[index] = inputData[index] + num_to_add;
         .unwrap();
 
     let output = ctx
-        .make_buffer(&BufferInfo {
+        .create_buffer(&BufferInfo {
             debug_name: "output_test",
             byte_size: BUFF_SIZE,
             visibility: MemoryVisibility::CpuAndGpu,


### PR DESCRIPTION
## Summary
- define a generic `Backend` trait with buffer creation and submit methods
- implement `Backend` for the Vulkan context and expose `create_buffer`
- rename `make_buffer` to `create_buffer` across examples and tests

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b35559fecc832a90876d59eb39e8bb