### PR TITLE
Unify command submission via Recorder trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ To try the OpenXR simple scene example (requires a VR headset), run:
 cargo run --no-default-features --features dashi-openxr --example openxr_simple_scene
 ```
 
+### Command Submission
+
+Dashi can record commands directly or via the heap-free `CommandEncoder`. The
+`Recorder` trait unifies both paths. Submit work with either a reference to an
+encoder or a closure that records onto the provided command list:
+
+```rust
+let mut list = ctx.begin_command_list(&CommandListInfo::default())?;
+let encoder = CommandEncoder::new();
+ctx.submit_with(&mut list, &encoder, &SubmitInfo::default())?;
+
+ctx.submit_with(&mut list, |cmd| {
+    // direct recording
+    cmd.draw(3, 1);
+}, &SubmitInfo::default())?;
+```
+
 Creating an image with `mip_levels` greater than 1 will automatically generate
 the full mip chain after the initial data upload.
 

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -1292,46 +1292,7 @@ impl CommandList {
 }
 
  impl CommandSink for CommandList {
-     fn begin_render_pass(&mut self, _pass: &crate::driver::command::BeginRenderPass) {
-//        let mut attachments: Vec<Attachment> = Vec::new();
-//        for i in 0..pass.color_count as usize {
-//            let color = pass.colors[i];
-//            attachments.push(Attachment {
-//                img: color.handle,
-//                clear: crate::ClearValue::Color(color.clear),
-//            });
-//        }
-//        if pass.has_depth == 1 {
-//            attachments.push(Attachment {
-//                img: Handle::new(pass.depth.handle.index(), pass.depth.handle.version()),
-//                clear: crate::ClearValue::DepthStencil {
-//                    depth: pass.depth.clear,
-//                    stencil: 0,
-//                },
-//            });
-//        }
-//        let render_pass_begin = RenderPassBegin {
-//            render_pass: Handle::new(0, 0),
-//            viewport: crate::Viewport {
-//                area: crate::FRect2D {
-//                    x: 0.0,
-//                    y: 0.0,
-//                    w: 1024.0,
-//                    h: 768.0,
-//                },
-//                scissor: crate::Rect2D {
-//                    x: 0,
-//                    y: 0,
-//                    w: 1024,
-//                    h: 768,
-//                },
-//                min_depth: 0.0,
-//                max_depth: 1.0,
-//            },
-//            attachments: &attachments,
-//        };
-//        self.begin_render_pass(&render_pass_begin).unwrap();
-     }
+    fn begin_render_pass(&mut self, _pass: &crate::driver::command::BeginRenderPass) {}
  
      fn end_render_pass(&mut self, _pass: &crate::driver::command::EndRenderPass) {
         unsafe { (*self.ctx).device.cmd_end_render_pass(self.cmd_buf) };

--- a/src/gpu/vulkan/framed_cmd_list.rs
+++ b/src/gpu/vulkan/framed_cmd_list.rs
@@ -1,5 +1,5 @@
 use crate::{
-    driver::command::CommandEncoder,
+    driver::command::Recorder,
     utils::Handle,
     CommandList,
     CommandListInfo,
@@ -99,17 +99,14 @@ impl FramedCommandList {
         Ok(())
     }
 
-    pub fn submit_encoder(
-        &mut self,
-        encoder: &CommandEncoder,
-        info: &SubmitInfo,
-    ) -> Result<()> {
+    pub fn record_submit<R>(&mut self, recorder: R, info: &SubmitInfo) -> Result<()>
+    where
+        R: Recorder<CommandList>,
+    {
         self.fences[self.curr as usize] = Some(unsafe {
-            self.ctx.as_mut().submit_encoder(
-                &mut self.cmds[self.curr as usize],
-                encoder,
-                info,
-            )?
+            self.ctx
+                .as_mut()
+                .submit_with(&mut self.cmds[self.curr as usize], recorder, info)?
         });
 
         self.advance();

--- a/src/gpu/vulkan/mod.rs
+++ b/src/gpu/vulkan/mod.rs
@@ -1,7 +1,6 @@
 mod error;
 use crate::{
-    driver::command::CommandEncoder,
-    ir::{CommandReplayer, Replayer},
+    driver::command::Recorder,
     utils::{Handle, Pool},
     sync::ResourceLookup,
 };
@@ -1003,19 +1002,16 @@ impl Context {
         return Ok(cmd.fence.clone());
     }
 
-    /// Replay a [`CommandEncoder`] on the given command list and submit it.
-    ///
-    /// The command list is reset before recording the encoded stream.
-    pub fn submit_encoder(
+    /// Reset the given command list, record commands using the provided recorder,
+    /// and submit it.
+    pub fn submit_with<R: Recorder<CommandList>>(
         &mut self,
         cmd: &mut CommandList,
-        encoder: &CommandEncoder,
+        recorder: R,
         info: &SubmitInfo,
     ) -> Result<Handle<Fence>, GPUError> {
         cmd.reset()?;
-        {
-            CommandReplayer::new(cmd).replay(encoder);
-        }
+        recorder.record(cmd);
         self.submit(cmd, info)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use gfx::cmd::{
     DescriptorWriteBuilder,
     DynamicRenderingBuilder,
 };
+pub use driver::command::Recorder;
 
 pub mod gpu;
 #[cfg(feature = "dx12")]

--- a/tests/submit_with.rs
+++ b/tests/submit_with.rs
@@ -1,15 +1,12 @@
-use dashi::{
-    driver::command::CommandEncoder,
-    *,
-};
+use dashi::{driver::command::CommandEncoder, *};
 
 #[test]
-fn submit_encoder() {
+fn submit_with_encoder() {
     let mut ctx = match gpu::Context::headless(&ContextInfo::default()) {
         Ok(ctx) => ctx,
         Err(err) => {
             eprintln!(
-                "Skipping submit_encoder test: Vulkan initialization unavailable: {:?}",
+                "Skipping submit_with test: Vulkan initialization unavailable: {:?}",
                 err
             );
             return;
@@ -22,7 +19,7 @@ fn submit_encoder() {
 
     let enc = CommandEncoder::new();
     let fence = ctx
-        .submit_encoder(&mut list, &enc, &SubmitInfo::default())
+        .submit_with(&mut list, &enc, &SubmitInfo::default())
         .unwrap();
     ctx.wait(fence).unwrap();
 


### PR DESCRIPTION
## Summary
- add `Recorder` trait to unify IR replays and direct command recording
- expose `Context::submit_with` and `FramedCommandList::record_submit` for single submission path
- document unified API and clean up outdated Vulkan code

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b3555db0e4832a9248b2c165d94323