### PR TITLE
Rename BindTableRes to BindTable

### DIFF
--- a/src/driver/command.rs
+++ b/src/driver/command.rs
@@ -5,7 +5,7 @@ use crate::{Image, Buffer};
 
 use super::{
     state::{StateTracker, SubresourceRange},
-    types::{BindTable as BindTableRes, Pipeline, UsageBits, Handle},
+    types::{BindTable, Pipeline, UsageBits, Handle},
 };
 
 //===----------------------------------------------------------------------===//
@@ -99,7 +99,7 @@ pub struct BindPipeline {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable, PartialEq, Eq)]
 pub struct BindTableCmd {
-    pub table: Handle<BindTableRes>,
+    pub table: Handle<BindTable>,
 }
 
 #[repr(C)]
@@ -252,7 +252,7 @@ impl CommandEncoder {
     }
 
     /// Bind a table of resources.
-    pub fn bind_table(&mut self, table: Handle<BindTableRes>) {
+    pub fn bind_table(&mut self, table: Handle<BindTable>) {
         let payload = BindTableCmd { table };
         self.push(Op::BindTable, &payload);
     }

--- a/src/gfx/cmd/mod.rs
+++ b/src/gfx/cmd/mod.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::{Buffer, Image};
 use crate::driver::command::{ColorAttachment, CommandEncoder, DepthAttachment, RenderPassDesc};
 use crate::driver::state::SubresourceRange;
-use crate::driver::types::{BindTable as BindTableRes, Handle, Pipeline};
+use crate::driver::types::{BindTable, Handle, Pipeline};
 
 /// Generic command buffer with type-state tracking.
 pub struct CommandBuffer<S> {
@@ -52,7 +52,7 @@ impl CommandBuffer<PipelineBound> {
         debug_assert!(self.render_pass_active, "draw outside render pass");
     }
 
-    pub fn bind_table(&mut self, _table: Handle<BindTableRes>) {}
+    pub fn bind_table(&mut self, _table: Handle<BindTable>) {}
 
     pub fn end(self) -> CommandBuffer<Executable> {
         debug_assert!(!self.render_pass_active, "render pass still active");
@@ -263,21 +263,21 @@ impl CommandBuilder for CommandEncoder {
 }
 
 pub trait PipelineBuilder {
-    fn bind_table(&mut self, table: Handle<BindTableRes>);
+    fn bind_table(&mut self, table: Handle<BindTable>);
 }
 
 impl PipelineBuilder for CommandBuffer<PipelineBound> {
-    fn bind_table(&mut self, _table: Handle<BindTableRes>) {}
+    fn bind_table(&mut self, _table: Handle<BindTable>) {}
 }
 
 impl PipelineBuilder for CommandEncoder {
-    fn bind_table(&mut self, table: Handle<BindTableRes>) {
+    fn bind_table(&mut self, table: Handle<BindTable>) {
         CommandEncoder::bind_table(self, table);
     }
 }
 
 pub struct DescriptorWriteBuilder {
-    table: Option<Handle<BindTableRes>>,
+    table: Option<Handle<BindTable>>,
 }
 
 impl DescriptorWriteBuilder {
@@ -285,7 +285,7 @@ impl DescriptorWriteBuilder {
         Self { table: None }
     }
 
-    pub fn table(mut self, table: Handle<BindTableRes>) -> Self {
+    pub fn table(mut self, table: Handle<BindTable>) -> Self {
         self.table = Some(table);
         self
     }

--- a/src/gpu/vulkan/builders.rs
+++ b/src/gpu/vulkan/builders.rs
@@ -2,7 +2,7 @@
 
 use crate::utils::Handle;
 use crate::{
-    AttachmentDescription, BindGroupLayout, BindTable, BindTableLayout, ComputePipeline,
+    AttachmentDescription, BindGroupLayout, BindTableLayout, ComputePipeline,
     ComputePipelineInfo, ComputePipelineLayout, ComputePipelineLayoutInfo, Display, DisplayInfo,
     GraphicsPipeline, GraphicsPipelineDetails, GraphicsPipelineInfo, GraphicsPipelineLayout,
     GraphicsPipelineLayoutInfo, PipelineShaderInfo, RenderPass, RenderPassInfo, SubpassDependency,
@@ -12,6 +12,7 @@ use crate::{Context, GPUError};
 #[cfg(feature = "dashi-openxr")]
 use crate::XrDisplayInfo;
 use smallvec::SmallVec;
+use super::descriptor_sets::BindTable;
 
 /// Builds a RenderPass via the builder pattern.
 pub struct RenderPassBuilder<'a> {

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -12,10 +12,11 @@ use super::{
 use crate::driver::command::CommandSink;
 use crate::utils::Handle;
 use crate::{
-    BarrierPoint, BindGroup, BindTable, Buffer, ClearValue, CommandList, ComputePipeline,
+    BarrierPoint, BindGroup, Buffer, ClearValue, CommandList, ComputePipeline,
     Context, DynamicBuffer, Filter, GPUError, GraphicsPipeline, IndexedBindGroup,
     IndexedIndirectCommand, IndirectCommand, Rect2D, Result, Viewport,
 };
+use super::descriptor_sets::BindTable;
 
 fn clear_value_to_vk(cv: &ClearValue) -> vk::ClearValue {
     match cv {

--- a/src/gpu/vulkan/structs.rs
+++ b/src/gpu/vulkan/structs.rs
@@ -2,7 +2,8 @@ use super::{
     BindGroupLayout, BindTableLayout, Buffer, ComputePipelineLayout, DynamicAllocator,
     GraphicsPipelineLayout, Image, RenderPass, Sampler, SelectedDevice,
 };
-use crate::{utils::Handle, BindGroup, BindTable, Semaphore};
+use crate::{utils::Handle, BindGroup, Semaphore};
+use super::descriptor_sets::BindTable;
 use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "dashi-serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod sync;
 pub mod gfx;
 pub mod framegraph;
 
-pub use driver::types::{Handle, IndexType, UsageBits};
+pub use driver::types::{BindTable, Handle, IndexType, UsageBits};
 pub use gfx::cmd::{
     CommandBuffer,
     CommandBuilder,

--- a/tests/ir_roundtrip.rs
+++ b/tests/ir_roundtrip.rs
@@ -4,7 +4,7 @@ use dashi::driver::command::{
     Draw, EndRenderPass, ImageBarrier, LoadOp, Op, RenderPassDesc, StoreOp,
 };
 use dashi::driver::state::SubresourceRange;
-use dashi::driver::types::{BindTable as BindTableRes, Handle, Pipeline};
+use dashi::driver::types::{BindTable, Handle, Pipeline};
 use dashi::{Buffer, Image};
 use dashi::ir::{CommandReplayer, Replayer};
 
@@ -75,7 +75,7 @@ fn ir_roundtrip_core_ops() {
     let buf_a = Handle::<Buffer>::new(3, 0);
     let buf_b = Handle::<Buffer>::new(4, 0);
     let pipe = Handle::<Pipeline>::new(5, 0);
-    let table = Handle::<BindTableRes>::new(6, 0);
+    let table = Handle::<BindTable>::new(6, 0);
     let range = SubresourceRange::new(0, 1, 0, 1);
 
     let color = ColorAttachment {


### PR DESCRIPTION
## Summary
- rename BindTableRes to BindTable across driver and gfx layers
- re-export BindTable in lib.rs and adjust Vulkan modules to disambiguate descriptor set BindTable
- update tests to use the unified name

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a92b14b0832aae3df1cea2dc4de9