### PR TITLE
Add documentation for handles and command helpers

### DIFF
--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -1,4 +1,17 @@
+/// Defines the interface that rendering backends must implement.
+///
+/// A backend wraps the low-level graphics API and exposes a
+/// type-safe [`Context`] used to create and manage GPU resources.
+///
+/// # Examples
+/// ```ignore
+/// use dashi::gpu::Backend;
+/// fn init<B: Backend>(ctx: B::Context) {
+///     // store the backend-specific context
+/// }
+/// ```
 pub trait Backend {
+    /// Backend specific context type used for resource creation.
     type Context;
 }
 


### PR DESCRIPTION
## Summary
- document backend trait and handle utilities
- explain buffer copy and binding structures with examples

## Testing
- `cargo check`
- `cargo test`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68b3d468b37c832ab673fdde6611a085