### PR TITLE
Refactor CommandBuilder implementations

### DIFF
--- a/src/gfx/cmd/mod.rs
+++ b/src/gfx/cmd/mod.rs
@@ -187,55 +187,45 @@ impl<'a> CommandBuilder for EncodeTarget<'a> {
     }
 }
 
-impl CommandBuilder for CommandBuffer<Recording> {
-    fn begin_render_pass<'a>(&mut self, desc: RenderPassDesc<'a>) {
-        self.enc.begin_render_pass(desc);
-    }
+trait CommandEncoderAccess {
+    fn enc(&mut self) -> &mut CommandEncoder;
+}
 
-    fn end_render_pass(&mut self) {
-        self.enc.end_render_pass();
-    }
-
-    fn begin_debug_label(&mut self, _label: &str) {
-        self.enc.begin_debug_marker();
-    }
-
-    fn end_debug_label(&mut self) {
-        self.enc.end_debug_marker();
-    }
-
-    fn texture_barrier(&mut self, image: Handle<Image>, range: SubresourceRange) {
-        self.enc.texture_barrier(image, range);
-    }
-
-    fn buffer_barrier(&mut self, buffer: Handle<Buffer>) {
-        self.enc.buffer_barrier(buffer);
+impl CommandEncoderAccess for CommandBuffer<Recording> {
+    fn enc(&mut self) -> &mut CommandEncoder {
+        &mut self.enc
     }
 }
 
-impl CommandBuilder for CommandBuffer<PipelineBound> {
+impl CommandEncoderAccess for CommandBuffer<PipelineBound> {
+    fn enc(&mut self) -> &mut CommandEncoder {
+        &mut self.enc
+    }
+}
+
+impl<T: CommandEncoderAccess> CommandBuilder for T {
     fn begin_render_pass<'a>(&mut self, desc: RenderPassDesc<'a>) {
-        self.enc.begin_render_pass(desc);
+        self.enc().begin_render_pass(desc);
     }
 
     fn end_render_pass(&mut self) {
-        self.enc.end_render_pass();
+        self.enc().end_render_pass();
     }
 
     fn begin_debug_label(&mut self, _label: &str) {
-        self.enc.begin_debug_marker();
+        self.enc().begin_debug_marker();
     }
 
     fn end_debug_label(&mut self) {
-        self.enc.end_debug_marker();
+        self.enc().end_debug_marker();
     }
 
     fn texture_barrier(&mut self, image: Handle<Image>, range: SubresourceRange) {
-        self.enc.texture_barrier(image, range);
+        self.enc().texture_barrier(image, range);
     }
 
     fn buffer_barrier(&mut self, buffer: Handle<Buffer>) {
-        self.enc.buffer_barrier(buffer);
+        self.enc().buffer_barrier(buffer);
     }
 }
 


### PR DESCRIPTION
## Summary
- unify shared CommandBuilder behavior behind an internal CommandEncoderAccess trait
- remove duplicated CommandBuilder impls for recording and pipeline-bound states

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6797820d8832aa5200c1bbbab0983