### PR TITLE
Rename copy_texture to copy_image

### DIFF
--- a/examples/compute_to_graphics.rs
+++ b/examples/compute_to_graphics.rs
@@ -31,8 +31,8 @@ impl CommandSink for PrintSink {
     fn copy_buffer(&mut self, _: &CopyBuffer) {
         println!("copy_buffer");
     }
-    fn copy_texture(&mut self, _: &CopyImage) {
-        println!("copy_texture");
+    fn copy_image(&mut self, _: &CopyImage) {
+        println!("copy_image");
     }
     fn texture_barrier(&mut self, _: &ImageBarrier) {
         println!("texture_barrier");
@@ -65,7 +65,7 @@ fn main() {
     let mut enc = CommandEncoder::new();
 
     // "Compute" step: copy data into the destination image.
-    enc.copy_texture(src, dst, range);
+    enc.copy_image(src, dst, range);
 
     // "Graphics" step: render to the same image.
     enc.begin_render_pass(RenderPassDesc { colors: &[color], depth: None });

--- a/src/driver/command.rs
+++ b/src/driver/command.rs
@@ -284,7 +284,7 @@ impl CommandEncoder {
     }
 
     /// Copy data between images, emitting required barriers.
-    pub fn copy_texture(
+    pub fn copy_image(
         &mut self,
         src: Handle<Image>,
         dst: Handle<Image>,
@@ -298,6 +298,17 @@ impl CommandEncoder {
         }
         let payload = CopyImage { src, dst };
         self.push(Op::CopyImage, &payload);
+    }
+
+    #[deprecated(note = "renamed to copy_image")]
+    /// Deprecated: renamed to [`copy_image`].
+    pub fn copy_texture(
+        &mut self,
+        src: Handle<Image>,
+        dst: Handle<Image>,
+        range: SubresourceRange,
+    ) {
+        self.copy_image(src, dst, range)
     }
 
     /// Begin a debug marker region.
@@ -333,7 +344,7 @@ impl CommandEncoder {
                 Op::Draw => sink.draw(cmd.payload()),
                 Op::Dispatch => sink.dispatch(cmd.payload()),
                 Op::CopyBuffer => sink.copy_buffer(cmd.payload()),
-                Op::CopyImage => sink.copy_texture(cmd.payload()),
+                Op::CopyImage => sink.copy_image(cmd.payload()),
                 Op::ImageBarrier => sink.texture_barrier(cmd.payload()),
                 Op::BufferBarrier => sink.buffer_barrier(cmd.payload()),
                 Op::DebugMarkerBegin => sink.debug_marker_begin(cmd.payload()),
@@ -473,7 +484,12 @@ pub trait CommandSink {
     fn draw(&mut self, cmd: &Draw);
     fn dispatch(&mut self, cmd: &Dispatch);
     fn copy_buffer(&mut self, cmd: &CopyBuffer);
-    fn copy_texture(&mut self, cmd: &CopyImage);
+    fn copy_image(&mut self, cmd: &CopyImage);
+    #[deprecated(note = "renamed to copy_image")]
+    /// Deprecated: renamed to [`copy_image`].
+    fn copy_texture(&mut self, cmd: &CopyImage) {
+        self.copy_image(cmd)
+    }
     fn texture_barrier(&mut self, cmd: &ImageBarrier);
     fn buffer_barrier(&mut self, cmd: &BufferBarrier);
     fn debug_marker_begin(&mut self, cmd: &DebugMarkerBegin);

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -1477,8 +1477,8 @@ impl CommandList {
         let _ = self.copy_buffer(info);
      }
  
-     fn copy_texture(&mut self, _cmd: &crate::driver::command::CopyImage) {
-     }
+    fn copy_image(&mut self, _cmd: &crate::driver::command::CopyImage) {
+    }
 
      fn texture_barrier(&mut self, _cmd: &crate::driver::command::ImageBarrier) {
 //        let barrier = ImageBarrier { view: Handle::new(cmd.image.index(), cmd.image.version()), src: BarrierPoint::BlitRead, dst: BarrierPoint::BlitWrite };

--- a/src/ir/replayer.rs
+++ b/src/ir/replayer.rs
@@ -33,7 +33,7 @@ pub trait Replayer<S: CommandSink> {
                     CommandSink::copy_buffer(sink, cmd.payload::<CopyBuffer>())
                 }
                 OpTag::CopyImage => {
-                    CommandSink::copy_texture(sink, cmd.payload::<CopyImage>())
+                    CommandSink::copy_image(sink, cmd.payload::<CopyImage>())
                 }
                 OpTag::ImageBarrier => {
                     CommandSink::texture_barrier(sink, cmd.payload::<ImageBarrier>())

--- a/tests/ir_roundtrip.rs
+++ b/tests/ir_roundtrip.rs
@@ -51,7 +51,7 @@ impl CommandSink for Recorder {
     fn copy_buffer(&mut self, cmd: &CopyBuffer) {
         self.cmds.push(Recorded::CopyBuffer(*cmd));
     }
-    fn copy_texture(&mut self, cmd: &CopyImage) {
+    fn copy_image(&mut self, cmd: &CopyImage) {
         self.cmds.push(Recorded::CopyImage(*cmd));
     }
     fn texture_barrier(&mut self, cmd: &ImageBarrier) {
@@ -89,7 +89,7 @@ fn ir_roundtrip_core_ops() {
 
     let mut enc = CommandEncoder::new();
     enc.begin_debug_marker();
-    enc.copy_texture(img_a, img_b, range);
+    enc.copy_image(img_a, img_b, range);
     enc.begin_render_pass(RenderPassDesc { colors: &[color], depth: None });
     enc.bind_pipeline(pipe);
     enc.bind_table(table);


### PR DESCRIPTION
## Summary
- rename copy_texture methods to copy_image across encoder and sink
- provide deprecated copy_texture aliases for migration
- update replayer, example, test, and Vulkan backend call sites

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ca88fe88832ab54c1e03392ad6ac