### PR TITLE
refactor: macro for command builder

### DIFF
--- a/tests/command_builder.rs
+++ b/tests/command_builder.rs
@@ -1,0 +1,9 @@
+use dashi::gfx::cmd::{CommandBuffer, CommandBuilder, Recording, PipelineBound};
+
+fn assert_impl<T: CommandBuilder>() {}
+
+#[test]
+fn command_buffer_states_impl_command_builder() {
+    assert_impl::<CommandBuffer<Recording>>();
+    assert_impl::<CommandBuffer<PipelineBound>>();
+}


### PR DESCRIPTION
## Summary
- use macro to implement CommandBuilder for command buffer state types
- test CommandBuffer states satisfy CommandBuilder

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ca8d6534832ab5d643a97d511890