### PR TITLE
Fix Pool clear assertion and add regression test

### DIFF
--- a/src/utils/handle.rs
+++ b/src/utils/handle.rs
@@ -469,7 +469,7 @@ impl<T> Pool<T> {
     pub fn clear(&mut self) {
         self.empty = (0..(self.items.len()) as u32).collect();
         self.generation.fill(0);
-        assert!(self.generation.is_empty());
+        assert!(!self.generation.is_empty());
     }
 }
 
@@ -500,6 +500,19 @@ mod tests {
         pool.for_each_occupied_mut(|f| {
             f._big_data[0] = 5;
         });
+    }
+
+    #[test]
+    #[serial]
+    fn test_clear_allows_inserts() {
+        #[derive(Default)]
+        struct S {
+            _val: u32,
+        }
+        let mut pool: Pool<S> = Pool::new(1);
+        assert!(pool.insert(S::default()).is_some());
+        pool.clear();
+        assert!(pool.insert(S::default()).is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- correct Pool::clear to maintain generation data
- add regression test verifying insert succeeds after clear

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b7caa25a54832aa66e286ceb1824b8