### PR TITLE
refactor: remove rendertarget for imageless framebuffer

### DIFF
--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -225,14 +225,6 @@ void main() {
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
-
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -327,13 +319,15 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                target: render_target,
-                clear_values: [
+                colors: [Some(fb_view), None, None, None],
+                depth: None,
+                color_clears: [
                     Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
                     None,
                     None,
                     None,
                 ],
+                depth_clear: None,
             });
 
             // Bump alloc some data to write the triangle position to.

--- a/examples/minifb_triangle.rs
+++ b/examples/minifb_triangle.rs
@@ -232,13 +232,6 @@ void main() {
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
 
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
@@ -288,7 +281,7 @@ void main() {
 
         framed_list.record(|list| {
             // Begin render pass & bind pipeline
-            list.begin_drawing(&DrawBegin {
+            list.begin_drawing(&BeginDrawing {
                 viewport: Viewport {
                     area: FRect2D {
                         w: WIDTH as f32,
@@ -303,8 +296,15 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                render_target,
-                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
+                colors: [Some(fb_view), None, None, None],
+                depth: None,
+                color_clears: [
+                    Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
+                    None,
+                    None,
+                    None,
+                ],
+                depth_clear: None,
             })
             .unwrap();
 

--- a/examples/openxr_simple_scene.rs
+++ b/examples/openxr_simple_scene.rs
@@ -181,13 +181,6 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
 
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -226,15 +219,22 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
         let vp = fov_to_projection(view.fov, 0.1, 100.0) * pose_to_view(view.pose);
 
         framed_list.record(|list| {
-            list.begin_drawing(&DrawBegin {
+            list.begin_drawing(&BeginDrawing {
                 viewport: Viewport {
                     area: FRect2D { w: width as f32, h: height as f32, ..Default::default() },
                     scissor: Rect2D { w: width, h: height, ..Default::default() },
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                render_target,
-                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
+                colors: [Some(fb_view), None, None, None],
+                depth: None,
+                color_clears: [
+                    Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
+                    None,
+                    None,
+                    None,
+                ],
+                depth_clear: None,
             }).unwrap();
             let mut buf = allocator.bump().unwrap();
             let mut mat = &mut buf.slice::<[f32; 16]>()[0];

--- a/examples/openxr_triangle.rs
+++ b/examples/openxr_triangle.rs
@@ -163,13 +163,6 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
 
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -199,15 +192,22 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
         let (_idx, state) = ctx.acquire_xr_image(&mut display).unwrap();
 
         framed_list.record(|list| {
-            list.begin_drawing(&DrawBegin {
+            list.begin_drawing(&BeginDrawing {
                 viewport: Viewport {
                     area: FRect2D { w: width as f32, h: height as f32, ..Default::default() },
                     scissor: Rect2D { w: width, h: height, ..Default::default() },
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                render_target,
-                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
+                colors: [Some(fb_view), None, None, None],
+                depth: None,
+                color_clears: [
+                    Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
+                    None,
+                    None,
+                    None,
+                ],
+                depth_clear: None,
             }).unwrap();
             let mut buf = allocator.bump().unwrap();
             let pos = &mut buf.slice::<[f32; 2]>()[0];

--- a/src/gpu/cmd/mod.rs
+++ b/src/gpu/cmd/mod.rs
@@ -1,12 +1,11 @@
 use std::marker::PhantomData;
 
 use crate::driver::command::{BeginDrawing, BlitImage, Dispatch, Draw, DrawIndexed};
-use crate::driver::state::SubresourceRange;
 use crate::driver::types::Handle;
 use crate::gpu::driver::command::{
     CommandEncoder, CommandSink, CopyBuffer, CopyBufferImage, CopyImageBuffer,
 };
-use crate::{BindTable, Buffer, ComputePipeline, Fence, GraphicsPipeline, Image, SubmitInfo2};
+use crate::{BindTable, Fence, GraphicsPipeline, SubmitInfo2};
 
 /// Generic command buffer with type-state tracking.
 pub struct CommandStream<S> {

--- a/src/gpu/driver/state.rs
+++ b/src/gpu/driver/state.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{Buffer, Image};
 
 use super::{
-    command::{BufferBarrier, ImageBarrier},
+    command::BufferBarrier,
     types::{Handle, UsageBits},
 };
 

--- a/src/gpu/vulkan/structs.rs
+++ b/src/gpu/vulkan/structs.rs
@@ -836,12 +836,6 @@ pub struct RenderPassInfo<'a> {
     pub subpasses: &'a [SubpassDescription<'a>],
 }
 
-pub struct RenderTargetInfo<'a> {
-    pub debug_name: &'a str,
-    pub render_pass: Handle<RenderPass>,
-    pub attachments: &'a [ImageView],
-}
-
 #[derive(Hash, Debug, Clone)]
 pub struct VertexDescriptionInfo<'a> {
     pub entries: &'a [VertexEntryInfo], // ConstSlice in Rust can be a reference slice

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -227,13 +227,6 @@ void main() {
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
 
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
@@ -327,8 +320,15 @@ void main() {
                         ..Default::default()
                     },
                     pipeline: graphics_pipeline,
-                    render_target,
-                    clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
+                    colors: [Some(fb_view), None, None, None],
+                    depth: None,
+                    color_clears: [
+                        Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
+                        None,
+                        None,
+                        None,
+                    ],
+                    depth_clear: None,
                 });
 
                 // Bump alloc some data to write the triangle position to.

--- a/tests/minifb_triangle.rs
+++ b/tests/minifb_triangle.rs
@@ -228,13 +228,6 @@ void main() {
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
 
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
@@ -284,7 +277,7 @@ void main() {
 
         framed_list.record(|list| {
             // Begin render pass & bind pipeline
-            list.begin_drawing(&DrawBegin {
+            list.begin_drawing(&BeginDrawing {
                 viewport: Viewport {
                     area: FRect2D {
                         w: WIDTH as f32,
@@ -299,8 +292,15 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                render_target,
-                clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
+                colors: [Some(fb_view), None, None, None],
+                depth: None,
+                color_clears: [
+                    Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
+                    None,
+                    None,
+                    None,
+                ],
+                depth_clear: None,
             })
             .unwrap();
 

--- a/tests/openxr_triangle.rs
+++ b/tests/openxr_triangle.rs
@@ -109,7 +109,6 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
         subpasses:&[SubpassDescription{color_attachments:&[AttachmentDescription{..Default::default()}],depth_stencil_attachment:None,subpass_dependencies:&[]}],
         debug_name:"renderpass"
     }).unwrap();
-    let render_target = ctx.make_render_target(&RenderTargetInfo{debug_name:"rt",render_pass,attachments:&[fb_view]}).unwrap();
     let graphics_pipeline = ctx.make_graphics_pipeline(&GraphicsPipelineInfo{layout:pipeline_layout,render_pass,debug_name:"Pipeline",..Default::default()}).unwrap();
     let mut allocator = ctx.make_dynamic_allocator(&Default::default()).unwrap();
     let bind_group = ctx.make_bind_group(&BindGroupInfo{debug_name:"OpenXR Triangle",layout:bg_layout,bindings:&[BindingInfo{resource:ShaderResource::Dynamic(&allocator),binding:0}],..Default::default()}).unwrap();
@@ -119,11 +118,13 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
     allocator.reset();
     let (_idx,state) = ctx.acquire_xr_image(&mut display).unwrap();
     framed_list.record(|list|{
-        list.begin_drawing(&DrawBegin{
+        list.begin_drawing(&BeginDrawing{
             viewport:Viewport{area:FRect2D{w:width as f32,h:height as f32,..Default::default()},scissor:Rect2D{w:width,h:height,..Default::default()},..Default::default()},
             pipeline:graphics_pipeline,
-            render_target,
-            clear_values:&[ClearValue::Color([0.0,0.0,0.0,1.0])]
+            colors:[Some(fb_view),None,None,None],
+            depth:None,
+            color_clears:[Some(ClearValue::Color([0.0,0.0,0.0,1.0])),None,None,None],
+            depth_clear:None
         }).unwrap();
         let mut buf=allocator.bump().unwrap();
         let pos=&mut buf.slice::<[f32;2]>()[0];

--- a/tests/pipeline_switch.rs
+++ b/tests/pipeline_switch.rs
@@ -18,7 +18,6 @@ fn pipeline_switch() {
         })
         .unwrap();
 
-    let view = ImageView { img, ..Default::default() };
 
     let rp = ctx
         .make_render_pass(&RenderPassInfo {
@@ -36,13 +35,6 @@ fn pipeline_switch() {
         })
         .unwrap();
 
-    let rt = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass: rp,
-            attachments: &[view],
-        })
-        .unwrap();
 
     let vert = inline_spirv::inline_spirv!(r"#version 450
         vec2 positions[3] = vec2[3](vec2(-0.5,-0.5), vec2(0.5,-0.5), vec2(0.0,0.5));


### PR DESCRIPTION
## Summary
- drop RenderTarget object and build imageless framebuffers during render pass creation
- begin_drawing now accepts attachment views and handles transitions for begin/end
- update examples and tests to pass color/depth attachments directly

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c700751744832a8cbd96af641babf9