### PR TITLE
Refactor render target handling to imageless framebuffers

### DIFF
--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -356,6 +356,9 @@ void main() {
                 ..Default::default()
             });
 
+            // Transition the display image for presentation
+            stream.prepare_for_presentation(img.img);
+
             stream.end().append(list);
         })
         .unwrap();

--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -225,14 +225,6 @@ void main() {
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
-
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -327,7 +319,8 @@ void main() {
                     ..Default::default()
                 },
                 pipeline: graphics_pipeline,
-                target: render_target,
+                color_attachments: [Some(fb_view), None, None, None],
+                depth_attachment: None,
                 clear_values: [
                     Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
                     None,

--- a/src/gpu/cmd/mod.rs
+++ b/src/gpu/cmd/mod.rs
@@ -64,6 +64,10 @@ impl CommandStream<Recording> {
         self.enc.blit_image(cmd);
     }
 
+    pub fn prepare_for_presentation(&mut self, image: Handle<Image>) {
+        self.enc.prepare_for_presentation(image);
+    }
+
     pub fn begin_drawing(mut self, cmd: &BeginDrawing) -> CommandStream<Graphics> {
         self.enc.begin_drawing(cmd);
         CommandStream {
@@ -96,6 +100,10 @@ impl CommandStream<Compute> {
 
     pub fn blit_images(&mut self, cmd: &BlitImage) {
         self.enc.blit_image(cmd);
+    }
+
+    pub fn prepare_for_presentation(&mut self, image: Handle<Image>) {
+        self.enc.prepare_for_presentation(image);
     }
 
     pub fn dispatch(&mut self, cmd: &Dispatch) {
@@ -138,6 +146,10 @@ impl CommandStream<Graphics> {
 
     pub fn blit_images(&mut self, cmd: &BlitImage) {
         self.enc.blit_image(cmd);
+    }
+
+    pub fn prepare_for_presentation(&mut self, image: Handle<Image>) {
+        self.enc.prepare_for_presentation(image);
     }
 
     pub fn draw(&mut self, cmd: &Draw) {

--- a/src/gpu/driver/command.rs
+++ b/src/gpu/driver/command.rs
@@ -471,6 +471,17 @@ impl CommandEncoder {
         self.push(Op::BlitImage, cmd);
     }
 
+    /// Transition an image to presentation layout.
+    pub fn prepare_for_presentation(&mut self, image: Handle<Image>) {
+        let range = SubresourceRange::default();
+        if let Some(bar) =
+            self.state
+                .request_image_state(image, range, UsageBits::PRESENT, Layout::Present)
+        {
+            self.push(Op::ImageBarrier, &bar);
+        }
+    }
+
     /// Begin a debug marker region.
     pub fn begin_debug_marker(&mut self) {
         self.push(Op::DebugMarkerBegin, &DebugMarkerBegin {});

--- a/src/gpu/driver/command.rs
+++ b/src/gpu/driver/command.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 
 use crate::{
     BindGroup, BindTable, Buffer, ClearValue, ComputePipeline, DynamicBuffer, Fence, Filter,
-    GraphicsPipeline, Image, ImageView, Rect2D, RenderTarget, SubmitInfo2, Viewport,
+    GraphicsPipeline, Image, ImageView, Rect2D, SubmitInfo2, Viewport,
 };
 
 use super::{
@@ -69,7 +69,8 @@ unsafe impl Pod for StoreOp {}
 pub struct BeginDrawing {
     pub viewport: Viewport,
     pub pipeline: Handle<GraphicsPipeline>,
-    pub target: Handle<RenderTarget>,
+    pub color_attachments: [Option<ImageView>; 4],
+    pub depth_attachment: Option<ImageView>,
     pub clear_values: [Option<ClearValue>; 4],
 }
 
@@ -333,6 +334,21 @@ impl CommandEncoder {
 
     /// Begin a render pass with the provided attachments.
     pub fn begin_drawing(&mut self, desc: &BeginDrawing) {
+        for view in desc.color_attachments.iter().flatten() {
+            let range = SubresourceRange::new(view.mip_level, 1, view.layer, 1);
+            let _ = self
+                .state
+                .request_image_state(view.img, range, UsageBits::RT_WRITE, Layout::ColorAttachment);
+        }
+        if let Some(view) = desc.depth_attachment {
+            let range = SubresourceRange::new(view.mip_level, 1, view.layer, 1);
+            let _ = self.state.request_image_state(
+                view.img,
+                range,
+                UsageBits::DEPTH_WRITE,
+                Layout::DepthStencilAttachment,
+            );
+        }
         self.push(Op::BeginDrawing, desc);
     }
 

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -773,6 +773,15 @@ impl CommandSink for CommandList {
                 &[barrier],
             )
         };
+        self.update_last_access(dst_stage, dst_access);
+
+        let img = self.ctx_ref().images.get_mut_ref(cmd.image).unwrap();
+        for level in 0..cmd.range.level_count {
+            let mip = (cmd.range.base_mip + level) as usize;
+            if let Some(l) = img.layouts.get_mut(mip) {
+                *l = layout_to_vk(cmd.new_layout);
+            }
+        }
     }
 
     fn buffer_barrier(&mut self, cmd: &crate::driver::command::BufferBarrier) {

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -3,7 +3,7 @@
 use ash::vk;
 
 use super::{
-    convert_barrier_point_vk, convert_rect2d_to_vulkan, ImageView, RenderTarget, VkImageView,
+    convert_barrier_point_vk, convert_rect2d_to_vulkan, ImageView, VkImageView,
 };
 use crate::driver::command::CommandSink;
 use crate::driver::state::vulkan::{USAGE_TO_ACCESS, USAGE_TO_STAGE};
@@ -235,45 +235,107 @@ impl CommandList {
 
 impl CommandSink for CommandList {
     fn begin_drawing(&mut self, cmd: &crate::driver::command::BeginDrawing) {
-        let rt = self
-            .ctx_ref()
-            .render_targets
-            .get_ref(cmd.target)
-            .ok_or(GPUError::SlotError())
-            .unwrap();
-        if self.curr_rp.map_or(false, |rp| rp == rt.render_pass) {
+        let pipeline_rp = {
+            let gfx = self
+                .ctx_ref()
+                .gfx_pipelines
+                .get_ref(cmd.pipeline)
+                .ok_or(GPUError::SlotError())
+                .unwrap();
+            gfx.render_pass
+        };
+
+        if self.curr_rp.map_or(false, |rp| rp == pipeline_rp) {
             return;
         }
+
         // end previous pass
         if self.curr_rp.is_some() {
             unsafe {
                 self.ctx_ref().device.cmd_end_render_pass(self.cmd_buf);
             }
+            // finalize CPU layouts for previous attachments
+            let attachments_prev = std::mem::take(&mut self.curr_attachments);
+            for (view, layout) in attachments_prev {
+                let ctx = self.ctx_ref();
+                let v = ctx.image_views.get_ref(view).unwrap();
+                let img = ctx.images.get_mut_ref(v.img).unwrap();
+                let base = v.range.base_mip_level as usize;
+                let count = v.range.level_count as usize;
+                for i in base..base + count {
+                    if let Some(l) = img.layouts.get_mut(i) {
+                        *l = layout;
+                    }
+                }
+            }
         }
-        self.curr_rp = Some(rt.render_pass);
+
+        self.curr_rp = Some(pipeline_rp);
+
+        let rp_obj = self
+            .ctx_ref()
+            .render_passes
+            .get_ref(pipeline_rp)
+            .ok_or(GPUError::SlotError())
+            .unwrap();
+
+        let mut attachments_vk: Vec<vk::ImageView> = Vec::new();
+        self.curr_attachments.clear();
+
+        for view in cmd.color_attachments.iter().flatten() {
+            let handle = self.ctx_ref().get_or_create_image_view(view).unwrap();
+            let vk_view = {
+                let v = self.ctx_ref().image_views.get_ref(handle).unwrap();
+                v.view
+            };
+            attachments_vk.push(vk_view);
+            self.curr_attachments
+                .push((handle, vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL));
+        }
+
+        if let Some(depth) = cmd.depth_attachment {
+            let handle = self.ctx_ref().get_or_create_image_view(&depth).unwrap();
+            let vk_view = {
+                let v = self.ctx_ref().image_views.get_ref(handle).unwrap();
+                v.view
+            };
+            attachments_vk.push(vk_view);
+            self.curr_attachments
+                .push((handle, vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL));
+        }
+
+        for (view_handle, layout) in &self.curr_attachments {
+            let ctx = self.ctx_ref();
+            let v = ctx.image_views.get_ref(*view_handle).unwrap();
+            let img = ctx.images.get_mut_ref(v.img).unwrap();
+            let base = v.range.base_mip_level as usize;
+            let count = v.range.level_count as usize;
+            for i in base..base + count {
+                if let Some(l) = img.layouts.get_mut(i) {
+                    *l = *layout;
+                }
+            }
+        }
+
+        let mut attachment_info = vk::RenderPassAttachmentBeginInfo::builder()
+            .attachments(&attachments_vk);
+
+        let clears: Vec<vk::ClearValue> = cmd
+            .clear_values
+            .iter()
+            .flatten()
+            .map(clear_value_to_vk)
+            .collect();
 
         unsafe {
-            let rp_obj = self
-                .ctx_ref()
-                .render_passes
-                .get_ref(rt.render_pass)
-                .ok_or(GPUError::SlotError())
-                .unwrap();
-
-            let clears: Vec<vk::ClearValue> = cmd
-                .clear_values
-                .iter() // Iterator<Item = &Option<ClearValue>>
-                .flatten() // Iterator<Item = &ClearValue> (drops Nones)
-                .map(clear_value_to_vk)
-                .collect();
-
             self.ctx_ref().device.cmd_begin_render_pass(
                 self.cmd_buf,
                 &vk::RenderPassBeginInfo::builder()
                     .render_pass(rp_obj.raw)
-                    .framebuffer(rt.fb)
+                    .framebuffer(rp_obj.fb)
                     .render_area(convert_rect2d_to_vulkan(cmd.viewport.scissor))
                     .clear_values(&clears)
+                    .push_next(&mut attachment_info)
                     .build(),
                 vk::SubpassContents::INLINE,
             );
@@ -287,6 +349,21 @@ impl CommandSink for CommandList {
         unsafe { (*self.ctx).device.cmd_end_render_pass(self.cmd_buf) };
         self.last_op_stage = vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT;
         self.last_op_access = vk::AccessFlags::COLOR_ATTACHMENT_WRITE;
+
+        let attachments = std::mem::take(&mut self.curr_attachments);
+        for (view, layout) in attachments {
+            let ctx = self.ctx_ref();
+            let v = ctx.image_views.get_ref(view).unwrap();
+            let img = ctx.images.get_mut_ref(v.img).unwrap();
+            let base = v.range.base_mip_level as usize;
+            let count = v.range.level_count as usize;
+            for i in base..base + count {
+                if let Some(l) = img.layouts.get_mut(i) {
+                    *l = layout;
+                }
+            }
+        }
+
         self.curr_rp = None;
         self.curr_pipeline = None;
     }

--- a/src/gpu/vulkan/display.rs
+++ b/src/gpu/vulkan/display.rs
@@ -455,16 +455,85 @@ impl Context {
             raw_wait_sems.push(self.semaphores.get_ref(sem.clone()).unwrap().raw);
         }
 
+        // Transition the swapchain image to PRESENT_SRC_KHR before presenting.
+        let img = self.images.get_ref(dsp.images[dsp.frame_idx as usize]).unwrap();
+        let cmd_buf = unsafe {
+            self.device
+                .allocate_command_buffers(
+                    &vk::CommandBufferAllocateInfo::builder()
+                        .command_pool(self.gfx_pool)
+                        .level(vk::CommandBufferLevel::PRIMARY)
+                        .command_buffer_count(1)
+                        .build(),
+                )?
+                [0]
+        };
+
         unsafe {
+            self.device.begin_command_buffer(
+                cmd_buf,
+                &vk::CommandBufferBeginInfo::builder()
+                    .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT)
+                    .build(),
+            )?;
+
+            let sub = vk::ImageSubresourceRange::builder()
+                .aspect_mask(vk::ImageAspectFlags::COLOR)
+                .level_count(1)
+                .layer_count(1)
+                .build();
+            let barrier = vk::ImageMemoryBarrier::builder()
+                .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+                .new_layout(vk::ImageLayout::PRESENT_SRC_KHR)
+                .image(img.img)
+                .subresource_range(sub)
+                .build();
+
+            self.device.cmd_pipeline_barrier(
+                cmd_buf,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                &[barrier],
+            );
+
+            self.device.end_command_buffer(cmd_buf)?;
+        }
+
+        let present_sem = unsafe {
+            self.device
+                .create_semaphore(&vk::SemaphoreCreateInfo::default(), None)?
+        };
+
+        let stage_masks = vec![vk::PipelineStageFlags::TRANSFER; raw_wait_sems.len()];
+        unsafe {
+            self.device.queue_submit(
+                self.gfx_queue.queue,
+                &[vk::SubmitInfo::builder()
+                    .command_buffers(&[cmd_buf])
+                    .wait_semaphores(&raw_wait_sems)
+                    .wait_dst_stage_mask(&stage_masks)
+                    .signal_semaphores(&[present_sem])
+                    .build()],
+                vk::Fence::null(),
+            )?;
+
+            self.device.free_command_buffers(self.gfx_pool, &[cmd_buf]);
+
             dsp.sc_loader.queue_present(
                 self.gfx_queue.queue,
                 &vk::PresentInfoKHR::builder()
                     .image_indices(&[dsp.frame_idx])
                     .swapchains(&[dsp.swapchain])
-                    .wait_semaphores(&raw_wait_sems)
+                    .wait_semaphores(&[present_sem])
                     .build(),
-            )
-        }?;
+            )?;
+
+            self.device.destroy_semaphore(present_sem, None);
+        }
 
         Ok(())
     }

--- a/src/gpu/vulkan/mod.rs
+++ b/src/gpu/vulkan/mod.rs
@@ -71,14 +71,9 @@ unsafe extern "system" fn vulkan_debug_callback(
 #[derive(Clone, Default)]
 pub struct RenderPass {
     pub(super) raw: vk::RenderPass,
+    pub(super) fb: vk::Framebuffer,
     pub(super) viewport: Viewport,
     pub(super) attachment_formats: Vec<Format>,
-}
-
-#[derive(Clone, Default)]
-pub struct RenderTarget {
-    pub(super) fb: vk::Framebuffer,
-    pub(super) render_pass: Handle<RenderPass>,
 }
 
 #[derive(Clone)]
@@ -115,6 +110,7 @@ pub struct CommandList {
     curr_pipeline: Option<Handle<GraphicsPipeline>>,
     last_op_access: vk::AccessFlags,
     last_op_stage: vk::PipelineStageFlags,
+    curr_attachments: Vec<(Handle<VkImageView>, vk::ImageLayout)>,
 }
 
 impl Default for CommandList {
@@ -128,6 +124,7 @@ impl Default for CommandList {
             curr_pipeline: None,
             last_op_access: vk::AccessFlags::TRANSFER_READ,
             last_op_stage: vk::PipelineStageFlags::ALL_COMMANDS,
+            curr_attachments: Vec::new(),
         }
     }
 }
@@ -154,7 +151,6 @@ pub struct Context {
     pub(super) transfer_queue: Option<Queue>,
     pub(super) buffers: Pool<Buffer>,
     pub(super) render_passes: Pool<RenderPass>,
-    pub(super) render_targets: Pool<RenderTarget>,
     pub(super) semaphores: Pool<Semaphore>,
     pub(super) fences: Pool<Fence>,
     pub(super) images: Pool<Image>,
@@ -373,6 +369,7 @@ impl Context {
         let wanted_extensions: Vec<*const c_char> = if windowed {
             vec![
                 ash::extensions::khr::Swapchain::name().as_ptr(),
+                vk::KhrImagelessFramebufferFn::name().as_ptr(),
                 unsafe {
                     std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_user_type\0").as_ptr()
                 },
@@ -381,9 +378,13 @@ impl Context {
                 KhrPortabilitySubsetFn::name().as_ptr(),
             ]
         } else {
-            vec![unsafe {
-                std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_user_type\0").as_ptr()
-            }]
+            vec![
+                vk::KhrImagelessFramebufferFn::name().as_ptr(),
+                unsafe {
+                    std::ffi::CStr::from_bytes_with_nul_unchecked(b"VK_GOOGLE_user_type\0").as_ptr()
+                },
+                vk::GoogleHlslFunctionality1Fn::name().as_ptr(),
+            ]
         };
 
         let extensions_to_enable: Vec<*const c_char> = wanted_extensions
@@ -405,6 +406,9 @@ impl Context {
             })
             .collect();
 
+        let mut imageless = vk::PhysicalDeviceImagelessFramebufferFeatures::default();
+        imageless.imageless_framebuffer = vk::TRUE;
+
         let device = unsafe {
             instance.create_device(
                 pdevice,
@@ -413,6 +417,7 @@ impl Context {
                     .queue_create_infos(&queue_infos)
                     .push_next(&mut features2)
                     .push_next(&mut features16bit)
+                    .push_next(&mut imageless)
                     .build(),
                 None,
             )
@@ -548,7 +553,6 @@ impl Context {
 
             buffers: Default::default(),
             render_passes: Default::default(),
-            render_targets: Default::default(),
             semaphores: Default::default(),
             fences: Default::default(),
             images: Default::default(),
@@ -654,7 +658,6 @@ impl Context {
 
             buffers: Default::default(),
             render_passes: Default::default(),
-            render_targets: Default::default(),
             semaphores: Default::default(),
             fences: Default::default(),
             images: Default::default(),
@@ -1585,14 +1588,10 @@ impl Context {
             }
         });
 
-        // Render targets
-        self.render_targets.for_each_occupied_mut(|rt| {
-            unsafe { self.device.destroy_framebuffer(rt.fb, None) };
-        });
-
         // Render passes
         self.render_passes.for_each_occupied_mut(|rp| {
             unsafe { self.device.destroy_render_pass(rp.raw, None) };
+            unsafe { self.device.destroy_framebuffer(rp.fb, None) };
         });
 
         // Graphics pipeline layouts
@@ -1751,21 +1750,15 @@ impl Context {
     /// - The context must still be alive.
     pub fn destroy_render_pass(&mut self, handle: Handle<RenderPass>) {
         let rp = self.render_passes.get_ref(handle).unwrap();
-        unsafe { self.device.destroy_render_pass(rp.raw, None) };
+        unsafe {
+            self.device.destroy_framebuffer(rp.fb, None);
+            self.device.destroy_render_pass(rp.raw, None);
+        }
         self.render_passes.release(handle);
     }
 
     /// Destroys a render target and its framebuffer.
     ///
-    /// # Prerequisites
-    /// - Ensure no GPU work is using the render target.
-    /// - The context must still be alive.
-    pub fn destroy_render_target(&mut self, handle: Handle<RenderTarget>) {
-        let rt = self.render_targets.get_ref(handle).unwrap();
-        unsafe { self.device.destroy_framebuffer(rt.fb, None) };
-        self.render_targets.release(handle);
-    }
-
     /// Destroys a command list and its associated fence.
     ///
     /// # Prerequisites
@@ -2645,77 +2638,53 @@ impl Context {
 
         // Create render pass
         let render_pass = unsafe { self.device.create_render_pass(&render_pass_info, None) }?;
-
         self.set_name(render_pass, info.debug_name, vk::ObjectType::RENDER_PASS);
+
+        let width = info.viewport.scissor.w;
+        let height = info.viewport.scissor.h;
+
+        let attachment_image_infos: Vec<vk::FramebufferAttachmentImageInfo> = attachment_formats
+            .iter()
+            .map(|fmt| {
+                let usage = if matches!(fmt, Format::D24S8) {
+                    vk::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT
+                } else {
+                    vk::ImageUsageFlags::COLOR_ATTACHMENT
+                };
+                let vk_fmt = lib_to_vk_image_format(fmt);
+                vk::FramebufferAttachmentImageInfo::builder()
+                    .usage(usage)
+                    .width(width)
+                    .height(height)
+                    .layer_count(1)
+                    .view_formats(std::slice::from_ref(&vk_fmt))
+                    .build()
+            })
+            .collect();
+
+        let mut attachments_info = vk::FramebufferAttachmentsCreateInfo::builder()
+            .attachment_image_infos(&attachment_image_infos);
+
+        let fb_info = vk::FramebufferCreateInfo::builder()
+            .flags(vk::FramebufferCreateFlags::IMAGELESS_KHR)
+            .render_pass(render_pass)
+            .width(width)
+            .height(height)
+            .layers(1)
+            .attachment_count(attachment_formats.len() as u32)
+            .push_next(&mut attachments_info);
+
+        let fb = unsafe { self.device.create_framebuffer(&fb_info, None) }?;
 
         return Ok(self
             .render_passes
             .insert(RenderPass {
                 raw: render_pass,
+                fb,
                 viewport: info.viewport,
                 attachment_formats,
             })
             .unwrap());
-    }
-
-    /// Create a render target from a set of image views and a render pass.
-    pub fn make_render_target(
-        &mut self,
-        info: &RenderTargetInfo,
-    ) -> Result<Handle<RenderTarget>, GPUError> {
-        let (attachment_formats, raw_rp) = {
-            let rp = self.render_passes.get_ref(info.render_pass).unwrap();
-            (rp.attachment_formats.clone(), rp.raw)
-        };
-
-        if attachment_formats.len() != info.attachments.len() {
-            return Err(GPUError::LibraryError());
-        }
-
-        let mut views = Vec::with_capacity(info.attachments.len());
-        let mut width = u32::MAX;
-        let mut height = u32::MAX;
-
-        for (img_view, fmt) in info.attachments.iter().zip(attachment_formats.iter()) {
-            let handle = self.get_or_create_image_view(img_view)?;
-            let (image_format, image_dim, vk_view) = {
-                let view = self.image_views.get_ref(handle).unwrap();
-                let image = self.images.get_ref(view.img).unwrap();
-                (image.format, image.dim, view.view)
-            };
-            if image_format != *fmt {
-                return Err(GPUError::LibraryError());
-            }
-            let is_depth = matches!(fmt, Format::D24S8);
-            let layout = if is_depth {
-                vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
-            } else {
-                vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
-            };
-            self.oneshot_transition_image(*img_view, layout);
-            width = width.min(image_dim[0]);
-            height = height.min(image_dim[1]);
-            views.push(vk_view);
-        }
-
-        let fb_info = vk::FramebufferCreateInfo {
-            render_pass: raw_rp,
-            attachment_count: views.len() as u32,
-            p_attachments: views.as_ptr(),
-            width,
-            height,
-            layers: 1,
-            ..Default::default()
-        };
-        let fb = unsafe { self.device.create_framebuffer(&fb_info, None)? };
-        self.set_name(fb, info.debug_name, vk::ObjectType::FRAMEBUFFER);
-        Ok(self
-            .render_targets
-            .insert(RenderTarget {
-                fb,
-                render_pass: info.render_pass,
-            })
-            .unwrap())
     }
 
     /// Creates a compute pipeline layout from shader and bind group layouts.

--- a/src/gpu/vulkan/structs.rs
+++ b/src/gpu/vulkan/structs.rs
@@ -836,12 +836,6 @@ pub struct RenderPassInfo<'a> {
     pub subpasses: &'a [SubpassDescription<'a>],
 }
 
-pub struct RenderTargetInfo<'a> {
-    pub debug_name: &'a str,
-    pub render_pass: Handle<RenderPass>,
-    pub attachments: &'a [ImageView],
-}
-
 #[derive(Hash, Debug, Clone)]
 pub struct VertexDescriptionInfo<'a> {
     pub entries: &'a [VertexEntryInfo], // ConstSlice in Rust can be a reference slice

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -227,14 +227,6 @@ void main() {
         })
         .unwrap();
 
-    let render_target = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass,
-            attachments: &[fb_view],
-        })
-        .unwrap();
-
     // Make a graphics pipeline. This matches a pipeline layout to a render pass.
     let graphics_pipeline = ctx
         .make_graphics_pipeline(&GraphicsPipelineInfo {
@@ -327,8 +319,14 @@ void main() {
                         ..Default::default()
                     },
                     pipeline: graphics_pipeline,
-                    render_target,
-                    clear_values: &[ClearValue::Color([0.0, 0.0, 0.0, 1.0])],
+                    color_attachments: [Some(fb_view), None, None, None],
+                    depth_attachment: None,
+                    clear_values: [
+                        Some(ClearValue::Color([0.0, 0.0, 0.0, 1.0])),
+                        None,
+                        None,
+                        None,
+                    ],
                 });
 
                 // Bump alloc some data to write the triangle position to.

--- a/tests/pipeline_switch.rs
+++ b/tests/pipeline_switch.rs
@@ -36,14 +36,6 @@ fn pipeline_switch() {
         })
         .unwrap();
 
-    let rt = ctx
-        .make_render_target(&RenderTargetInfo {
-            debug_name: "rt",
-            render_pass: rp,
-            attachments: &[view],
-        })
-        .unwrap();
-
     let vert = inline_spirv::inline_spirv!(r"#version 450
         vec2 positions[3] = vec2[3](vec2(-0.5,-0.5), vec2(0.5,-0.5), vec2(0.0,0.5));
         void main() {


### PR DESCRIPTION
## Summary
- drop `RenderTarget` and pass attachments directly into `BeginDrawing`
- require `VK_KHR_imageless_framebuffer` and create framebuffers when making render passes
- track attachment layout transitions on `CommandList` begin/end

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c709c26dd0832aa8d7c796e7bd746f