### PR TITLE
Rename CommandList to CommandQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Dashi can record commands directly or via the heap-free `CommandEncoder`. The
 encoder or a closure that records onto the provided command list:
 
 ```rust
-let mut list = ctx.begin_command_list(&CommandListInfo::default())?;
+let mut list = ctx.begin_command_queue(&CommandQueueInfo {
+    queue_type: QueueType::Graphics,
+    ..Default::default()
+})?;
 let encoder = CommandEncoder::new();
 ctx.submit_with(&mut list, &encoder, &SubmitInfo::default())?;
 

--- a/examples/gpu_timing.rs
+++ b/examples/gpu_timing.rs
@@ -5,7 +5,7 @@ fn main() {
     // GPU timers must be initialized before use.
     ctx.init_gpu_timers(1).unwrap();
 
-    let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+    let mut list = ctx.begin_command_queue(&Default::default()).unwrap();
     // Begin and end must bracket commands on the same list.
     ctx.gpu_timer_begin(&mut list, 0);
     // no-op workload

--- a/examples/hello_triangle.rs
+++ b/examples/hello_triangle.rs
@@ -258,7 +258,7 @@ void main() {
 
     timer.start();
     let mut ring = ctx
-        .make_command_ring(&CommandListInfo2 {
+        .make_command_ring(&CommandQueueInfo2 {
             debug_name: "cmd",
             ..Default::default()
         })

--- a/examples/minifb_triangle.rs
+++ b/examples/minifb_triangle.rs
@@ -272,7 +272,8 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3).unwrap();
+    let mut framed_list =
+        FramedCommandQueue::new(&mut ctx, "Default", 3, QueueType::Graphics).unwrap();
     let sems = ctx.make_semaphores(2).unwrap();
     'running: while display.minifb_window().is_open() {
         // Reset the allocator

--- a/examples/openxr_simple_scene.rs
+++ b/examples/openxr_simple_scene.rs
@@ -210,7 +210,8 @@ void main() { out_color = vec4(0.2, 0.8, 0.2, 1.0); }", frag),
 
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2).unwrap();
+    let mut framed_list =
+        FramedCommandQueue::new(&mut ctx, "Default", 2, QueueType::Graphics).unwrap();
 
     for _ in 0..100 {
         allocator.reset();

--- a/examples/openxr_triangle.rs
+++ b/examples/openxr_triangle.rs
@@ -192,7 +192,8 @@ void main() { out_color = vec4(frag_color.xy, 0, 1); }", frag),
 
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 2).unwrap();
+    let mut framed_list =
+        FramedCommandQueue::new(&mut ctx, "Default", 2, QueueType::Graphics).unwrap();
 
     for _ in 0..100 {
         allocator.reset();

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -1,4 +1,4 @@
-//! Refactored command helpers for Dashi CommandList
+//! Refactored command helpers for Dashi CommandQueue
 
 use ash::vk;
 
@@ -10,7 +10,7 @@ use crate::driver::state::vulkan::{USAGE_TO_ACCESS, USAGE_TO_STAGE};
 use crate::driver::state::{Layout, LayoutTransition};
 use crate::utils::Handle;
 use crate::{
-    BarrierPoint, BindGroup, BindTable, Buffer, ClearValue, CommandList, ComputePipeline, Context, DynamicBuffer, Fence, Filter, GPUError, GraphicsPipeline, IndexedBindGroup, IndexedIndirectCommand, IndirectCommand, Rect2D, Result, Semaphore, SubmitInfo, SubmitInfo2, UsageBits, Viewport
+    BarrierPoint, BindGroup, BindTable, Buffer, ClearValue, CommandQueue, ComputePipeline, Context, DynamicBuffer, Fence, Filter, GPUError, GraphicsPipeline, IndexedBindGroup, IndexedIndirectCommand, IndirectCommand, Rect2D, Result, Semaphore, SubmitInfo, SubmitInfo2, UsageBits, Viewport
 };
 
 // --- New: helpers to map engine Layout/UsageBits to Vulkan ---
@@ -74,7 +74,7 @@ fn clear_value_to_vk(cv: &ClearValue) -> vk::ClearValue {
     }
 }
 
-impl CommandList {
+impl CommandQueue {
     /// Reset the command buffer and begin recording again.
     ///
     /// # Vulkan prerequisites
@@ -135,7 +135,7 @@ impl CommandList {
 
             let stage_masks = vec![vk::PipelineStageFlags::ALL_COMMANDS; raw_wait_sems.len()];
 
-            let queue = (*self.ctx).gfx_queue.queue;
+            let queue = (*self.ctx).queue(self.queue_type);
             (*self.ctx).device.queue_submit(
                 queue,
                 &[vk::SubmitInfo::builder()
@@ -233,7 +233,7 @@ impl CommandList {
     }
 }
 
-impl CommandSink for CommandList {
+impl CommandSink for CommandQueue {
     fn begin_drawing(&mut self, cmd: &crate::driver::command::BeginDrawing) {
         let pipeline_rp = {
             let gfx = self

--- a/src/gpu/vulkan/descriptor_sets.rs
+++ b/src/gpu/vulkan/descriptor_sets.rs
@@ -37,7 +37,7 @@ pub struct IndexedBindGroup {
     pub(super) set_id: u32,
 }
 
-impl CommandList {
+impl CommandQueue {
     pub(crate) fn bind_descriptor_set(
         &mut self,
         bind_point: vk::PipelineBindPoint,

--- a/src/gpu/vulkan/structs.rs
+++ b/src/gpu/vulkan/structs.rs
@@ -2,7 +2,7 @@ use super::{
     BindGroupLayout, BindTableLayout, Buffer, ComputePipelineLayout, DynamicAllocator,
     GraphicsPipelineLayout, Image, RenderPass, Sampler, SelectedDevice,
 };
-use crate::{utils::Handle, BindGroup, BindTable, CommandList, Semaphore};
+use crate::{utils::Handle, BindGroup, BindTable, CommandQueue, Semaphore};
 use std::hash::{Hash, Hasher};
 
 use bytemuck::{Pod, Zeroable};
@@ -334,23 +334,25 @@ impl<'a> Default for DynamicAllocatorInfo<'a> {
 }
 
 #[derive(Hash)]
-pub struct CommandListInfo<'a> {
+pub struct CommandQueueInfo<'a> {
     pub debug_name: &'a str,
     pub should_cleanup: bool,
-}
-
-#[derive(Default)]
-pub struct CommandListInfo2<'a> {
-    pub debug_name: &'a str,
-    pub parent: Option<&'a CommandList>,
     pub queue_type: QueueType,
 }
 
-impl<'a> Default for CommandListInfo<'a> {
+#[derive(Default)]
+pub struct CommandQueueInfo2<'a> {
+    pub debug_name: &'a str,
+    pub parent: Option<&'a CommandQueue>,
+    pub queue_type: QueueType,
+}
+
+impl<'a> Default for CommandQueueInfo<'a> {
     fn default() -> Self {
         Self {
             debug_name: "",
             should_cleanup: true,
+            queue_type: QueueType::Graphics,
         }
     }
 }

--- a/src/utils/gpupool.rs
+++ b/src/utils/gpupool.rs
@@ -1,4 +1,4 @@
-use crate::{driver::command::CopyBuffer, cmd::{Initial, Pending}, Buffer, BufferInfo, CommandList, CommandStream, Context, MemoryVisibility};
+use crate::{driver::command::CopyBuffer, cmd::{Initial, Pending}, Buffer, BufferInfo, CommandQueue, CommandStream, Context, MemoryVisibility};
 
 use super::{Handle, Pool};
 use crate::Result;
@@ -54,7 +54,7 @@ impl<T> GPUPool<T> {
         return self.buffer;
     }
 
-    pub fn sync_down(&mut self, list: &mut CommandList) -> Result<()> {
+    pub fn sync_down(&mut self, list: &mut CommandQueue) -> Result<()> {
 
         let mut cmd = CommandStream::new().begin();
         cmd.copy_buffers(&CopyBuffer {
@@ -67,7 +67,7 @@ impl<T> GPUPool<T> {
         Ok(())
     }
 
-    pub fn sync_up(&mut self, list: &mut CommandList) -> Result<()> {
+    pub fn sync_up(&mut self, list: &mut CommandQueue) -> Result<()> {
         let mut cmd = CommandStream::new().begin();
         cmd.copy_buffers(&CopyBuffer {
             src: self.staging,
@@ -161,7 +161,7 @@ mod tests {
         }
         assert!(pool.len() == TEST_AMT);
 
-        let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+        let mut list = ctx.begin_command_queue(&Default::default()).unwrap();
         pool.sync_up(&mut list).unwrap();
         ctx.submit(&mut list, &Default::default())
             .expect("ASSERT: Should be able to sync data up");

--- a/tests/compute_then_graphics.rs
+++ b/tests/compute_then_graphics.rs
@@ -162,7 +162,7 @@
 //    });
 //    let compute = graph.add_node(Node::new(compute_decl, move || {
 //        let ctx = unsafe { &mut *(ctx_ptr as *mut Context) };
-//        let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+//        let mut list = ctx.begin_command_queue(&Default::default()).unwrap();
 //        list.dispatch_compute(Dispatch {
 //            compute: comp_pipe,
 //            workgroup_size: [1,1,1],
@@ -174,7 +174,7 @@
 //        });
 //        let fence = ctx.submit(&mut list, &Default::default()).unwrap();
 //        ctx.wait(fence).unwrap();
-//        ctx.destroy_cmd_list(list);
+//        ctx.destroy_cmd_queue(list);
 //    }));
 //
 //    let mut graphics_decl = PassDecl::new();
@@ -199,7 +199,7 @@
 //
 //    let graphics = graph.add_node(Node::new(graphics_decl, move || {
 //        let ctx = unsafe { &mut *(ctx_ptr as *mut Context) };
-//        let mut list = ctx.begin_command_list(&CommandListInfo { debug_name: "draw", ..Default::default() }).unwrap();
+//        let mut list = ctx.begin_command_queue(&CommandQueueInfo { debug_name: "draw", ..Default::default() }).unwrap();
 //        list.begin_drawing(&DrawBegin {
 //            viewport: Viewport {
 //                area: FRect2D { w: WIDTH as f32, h: HEIGHT as f32, ..Default::default() },
@@ -222,7 +222,7 @@
 //        list.end_drawing().unwrap();
 //        let fence = ctx.submit(&mut list, &Default::default()).unwrap();
 //        ctx.wait(fence).unwrap();
-//        ctx.destroy_cmd_list(list);
+//        ctx.destroy_cmd_queue(list);
 //    }));
 //
 //    graph.add_dependency(graphics, compute);
@@ -234,7 +234,7 @@
 ////    let readback = ctx
 ////        .make_buffer(&BufferInfo { debug_name: "readback", byte_size: (WIDTH*HEIGHT*4) as u32, visibility: MemoryVisibility::CpuAndGpu, ..Default::default() })
 ////        .unwrap();
-////    let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+////    let mut list = ctx.begin_command_queue(&Default::default()).unwrap();
 ////    list.copy_image_to_buffer(ImageBufferCopy { src: view, dst: readback, dst_offset: 0 });
 ////    let fence = ctx.submit(&mut list, &Default::default()).unwrap();
 ////    ctx.wait(fence).unwrap();
@@ -243,7 +243,7 @@
 ////    fs::create_dir_all("tests/output").unwrap();
 ////    save_buffer("tests/output/compute_then_graphics.png", &data, WIDTH, HEIGHT, ColorType::Rgba8).unwrap();
 //
-//    ctx.destroy_cmd_list(list);
+//    ctx.destroy_cmd_queue(list);
 //    ctx.destroy_buffer(readback);
 //    ctx.destroy_buffer(color_buf);
 //    ctx.destroy_buffer(vb);

--- a/tests/framebuffer_compare.rs
+++ b/tests/framebuffer_compare.rs
@@ -35,7 +35,7 @@ fn framebuffer_compare() {
         .unwrap();
 
 //    let mut list = ctx
-//        .begin_command_list(&CommandListInfo { debug_name: "copy", ..Default::default() })
+//        .begin_command_queue(&CommandQueueInfo { debug_name: "copy", ..Default::default() })
 //        .unwrap();
 //    list.copy_image_to_buffer(ImageBufferCopy { src: view, dst: buffer, dst_offset: 0 });
 //    let fence = ctx.submit(&mut list, &Default::default()).unwrap();
@@ -46,7 +46,7 @@ fn framebuffer_compare() {
 //
 //    assert!(compare_rgba(&actual, &expected, width, height, 0));
 
-//    ctx.destroy_cmd_list(list);
+//    ctx.destroy_cmd_queue(list);
     ctx.destroy_buffer(buffer);
     ctx.destroy_image(image);
     ctx.destroy();

--- a/tests/gpu_timer.rs
+++ b/tests/gpu_timer.rs
@@ -16,7 +16,7 @@ fn gpu_timer() {
     ctx.init_gpu_timers(1).unwrap();
 
     let mut list = ctx
-        .begin_command_list(&CommandListInfo { debug_name: "timer", ..Default::default() })
+        .begin_command_queue(&CommandQueueInfo { debug_name: "timer", ..Default::default() })
         .unwrap();
     // Begin and end must bracket commands on the same list.
     ctx.gpu_timer_begin(&mut list, 0);
@@ -29,6 +29,6 @@ fn gpu_timer() {
     let elapsed = ctx.get_elapsed_gpu_time_ms(0).unwrap();
     assert!(elapsed >= 0.0);
 
-    ctx.destroy_cmd_list(list);
+    ctx.destroy_cmd_queue(list);
     ctx.destroy();
 }

--- a/tests/hello_bindless/bin.rs
+++ b/tests/hello_bindless/bin.rs
@@ -82,7 +82,7 @@ fn main() {
     .unwrap();
 
     // Bind the table in a command list and dispatch.
-    let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+    let mut list = ctx.begin_command_queue(&Default::default()).unwrap();
     let buf = allocator.bump().unwrap();
     list.dispatch_compute(Dispatch {
         compute: pipeline,

--- a/tests/hello_triangle/bin.rs
+++ b/tests/hello_triangle/bin.rs
@@ -262,7 +262,7 @@ void main() {
 
     timer.start();
     let mut ring = ctx
-        .make_command_ring(&CommandListInfo2 { debug_name: "cmd" })
+        .make_command_ring(&CommandQueueInfo2 { debug_name: "cmd" })
         .unwrap();
 
     let sems = ctx.make_semaphores(2).unwrap();

--- a/tests/minifb_triangle.rs
+++ b/tests/minifb_triangle.rs
@@ -268,7 +268,8 @@ void main() {
     let mut timer = Timer::new();
 
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx, "Default", 3).unwrap();
+    let mut framed_list =
+        FramedCommandQueue::new(&mut ctx, "Default", 3, QueueType::Graphics).unwrap();
     let sems = ctx.make_semaphores(2).unwrap();
     'running: while display.minifb_window().is_open() {
         // Reset the allocator

--- a/tests/mipmap_generation.rs
+++ b/tests/mipmap_generation.rs
@@ -37,7 +37,7 @@ fn mipmap_generation() {
         .unwrap();
 
 //    let mut list = ctx
-//        .begin_command_list(&Default::default())
+//        .begin_command_queue(&Default::default())
 //        .unwrap();
 //    list.copy_image_to_buffer(ImageBufferCopy { src: view, dst: buffer, dst_offset: 0 });
 //    let fence = ctx.submit(&mut list, &Default::default()).unwrap();
@@ -48,7 +48,7 @@ fn mipmap_generation() {
 //
 //    assert_eq!(actual, vec![255u8, 0, 0, 255]);
 
-//    ctx.destroy_cmd_list(list);
+//    ctx.destroy_cmd_queue(list);
     ctx.destroy_buffer(buffer);
     ctx.destroy_image(image);
     ctx.destroy();

--- a/tests/openxr_triangle.rs
+++ b/tests/openxr_triangle.rs
@@ -115,7 +115,8 @@ void main(){ out_color=vec4(frag_color.xy,0,1); }",frag),
     let bind_group = ctx.make_bind_group(&BindGroupInfo{debug_name:"OpenXR Triangle",layout:bg_layout,bindings:&[BindingInfo{resource:ShaderResource::Dynamic(&allocator),binding:0}],..Default::default()}).unwrap();
     let mut timer = Timer::new();
     timer.start();
-    let mut framed_list = FramedCommandList::new(&mut ctx,"Default",2).unwrap();
+    let mut framed_list =
+        FramedCommandQueue::new(&mut ctx, "Default", 2, QueueType::Graphics).unwrap();
     allocator.reset();
     let (_idx,state) = ctx.acquire_xr_image(&mut display).unwrap();
     framed_list.record(|list|{

--- a/tests/pipeline_switch.rs
+++ b/tests/pipeline_switch.rs
@@ -110,7 +110,7 @@ fn pipeline_switch() {
         .unwrap();
 
 //    let mut list = ctx
-//        .begin_command_list(&CommandListInfo { debug_name: "draw", ..Default::default() })
+//        .begin_command_queue(&CommandQueueInfo { debug_name: "draw", ..Default::default() })
 //        .unwrap();
 //
 //    list.begin_drawing(&DrawBegin {
@@ -134,6 +134,6 @@ fn pipeline_switch() {
 //    let fence = ctx.submit(&mut list, &Default::default()).unwrap();
 //    ctx.wait(fence).unwrap();
 
-//    ctx.destroy_cmd_list(list);
+//    ctx.destroy_cmd_queue(list);
     ctx.destroy();
 }

--- a/tests/submit_with.rs
+++ b/tests/submit_with.rs
@@ -14,7 +14,7 @@
 //    };
 //
 //    let mut list = ctx
-//        .begin_command_list(&CommandListInfo { debug_name: "encoder", ..Default::default() })
+//        .begin_command_queue(&CommandQueueInfo { debug_name: "encoder", ..Default::default() })
 //        .unwrap();
 //
 //    let enc = CommandEncoder::new();
@@ -23,7 +23,7 @@
 //        .unwrap();
 //    ctx.wait(fence).unwrap();
 //
-//    ctx.destroy_cmd_list(list);
+//    ctx.destroy_cmd_queue(list);
 //    ctx.destroy();
 //}
 //

--- a/tests/vulkan_api.rs
+++ b/tests/vulkan_api.rs
@@ -259,7 +259,7 @@ outputData[index] = inputData[index] + num_to_add;
     allocator.reset();
 
     // Begin recording commands
-//    let mut list = ctx.begin_command_list(&Default::default()).unwrap();
+//    let mut list = ctx.begin_command_queue(&Default::default()).unwrap();
 //
 //    // Bump alloc some data to write the triangle position to.
 //    let mut buf = allocator.bump().unwrap();


### PR DESCRIPTION
## Summary
- rename CommandList to CommandQueue across core Vulkan backend and utils
- allow selecting queue type when constructing CommandQueue and CommandRing, routing submission and cleanup to the matching Vulkan queue

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c74d1a6e00832a8569bfbed15f4994