### PR TITLE
Add Vulkan command pool abstraction

### DIFF
--- a/src/gpu/vulkan/command_pool.rs
+++ b/src/gpu/vulkan/command_pool.rs
@@ -1,0 +1,192 @@
+use ash::vk;
+use std::{cell::UnsafeCell, marker::PhantomData, thread::ThreadId};
+
+use crate::{utils::Handle, Result};
+
+use super::{CommandQueue, Context, Fence, QueueType};
+
+/// Thin wrapper around a Vulkan command pool.
+///
+/// Handles allocation and recycling of primary/secondary command buffers and
+/// enforces single-threaded ownership. The pool may be moved to another thread
+/// after creation but must not be shared across threads.
+pub struct CommandPool {
+    ctx: *mut Context,
+    raw: vk::CommandPool,
+    queue_type: QueueType,
+    free_primary: Vec<vk::CommandBuffer>,
+    free_secondary: Vec<vk::CommandBuffer>,
+    owner: ThreadId,
+    // make !Sync
+    _not_sync: PhantomData<UnsafeCell<()>>,
+}
+
+impl Default for CommandPool {
+    fn default() -> Self {
+        Self {
+            ctx: std::ptr::null_mut(),
+            raw: vk::CommandPool::null(),
+            queue_type: QueueType::Graphics,
+            free_primary: Vec::new(),
+            free_secondary: Vec::new(),
+            owner: std::thread::current().id(),
+            _not_sync: PhantomData,
+        }
+    }
+}
+
+unsafe impl Send for CommandPool {}
+
+impl CommandPool {
+    /// Create a new command pool for the specified queue type.
+    pub(super) fn new(ctx: *mut Context, queue_type: QueueType) -> Result<Self> {
+        let family = match queue_type {
+            QueueType::Graphics => unsafe { (*ctx).gfx_queue.family },
+            QueueType::Compute => unsafe {
+                (*ctx)
+                    .compute_queue
+                    .as_ref()
+                    .unwrap_or(&(*ctx).gfx_queue)
+                    .family
+            },
+            QueueType::Transfer => unsafe {
+                (*ctx)
+                    .transfer_queue
+                    .as_ref()
+                    .or((*ctx).compute_queue.as_ref())
+                    .unwrap_or(&(*ctx).gfx_queue)
+                    .family
+            },
+        };
+
+        let ci = vk::CommandPoolCreateInfo::builder()
+            .queue_family_index(family)
+            .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER)
+            .build();
+        let raw = unsafe { (*ctx).device.create_command_pool(&ci, None)? };
+
+        Ok(Self {
+            ctx,
+            raw,
+            queue_type,
+            free_primary: Vec::new(),
+            free_secondary: Vec::new(),
+            owner: std::thread::current().id(),
+            _not_sync: PhantomData,
+        })
+    }
+
+    fn assert_owner(&self) {
+        debug_assert_eq!(
+            self.owner,
+            std::thread::current().id(),
+            "CommandPool used from wrong thread"
+        );
+    }
+
+    fn alloc(&mut self, level: vk::CommandBufferLevel) -> Result<vk::CommandBuffer> {
+        self.assert_owner();
+        let list = match level {
+            vk::CommandBufferLevel::PRIMARY => &mut self.free_primary,
+            vk::CommandBufferLevel::SECONDARY => &mut self.free_secondary,
+            _ => unreachable!(),
+        };
+        if let Some(buf) = list.pop() {
+            unsafe {
+                (*self.ctx).device.reset_command_buffer(
+                    buf,
+                    vk::CommandBufferResetFlags::empty(),
+                )?;
+            }
+            Ok(buf)
+        } else {
+            let cmd = unsafe {
+                (*self.ctx).device.allocate_command_buffers(
+                    &vk::CommandBufferAllocateInfo::builder()
+                        .command_pool(self.raw)
+                        .level(level)
+                        .command_buffer_count(1)
+                        .build(),
+                )?
+            };
+            Ok(cmd[0])
+        }
+    }
+
+    /// Begin recording a command queue from this pool.
+    pub fn begin(&mut self, debug_name: &str, is_secondary: bool) -> Result<CommandQueue> {
+        let level = if is_secondary {
+            vk::CommandBufferLevel::SECONDARY
+        } else {
+            vk::CommandBufferLevel::PRIMARY
+        };
+        let cmd_buf = self.alloc(level)?;
+
+        unsafe {
+            (*self.ctx).set_name(cmd_buf, debug_name, vk::ObjectType::COMMAND_BUFFER);
+
+            let f = (*self.ctx).device.create_fence(
+                &vk::FenceCreateInfo::builder()
+                    .flags(vk::FenceCreateFlags::empty())
+                    .build(),
+                None,
+            )?;
+            (*self.ctx).set_name(
+                f,
+                format!("{}.fence", debug_name).as_str(),
+                vk::ObjectType::FENCE,
+            );
+
+            (*self.ctx).device.begin_command_buffer(
+                cmd_buf,
+                &vk::CommandBufferBeginInfo::builder().build(),
+            )?;
+
+            Ok(CommandQueue {
+                cmd_buf,
+                fence: (*self.ctx).fences.insert(Fence::new(f)).unwrap(),
+                dirty: true,
+                ctx: self.ctx,
+                pool: self,
+                queue_type: self.queue_type,
+                is_secondary,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Recycle a command queue after GPU completion, returning its fence handle.
+    pub fn recycle(&mut self, list: CommandQueue) -> Handle<Fence> {
+        self.assert_owner();
+        let buf = list.cmd_buf;
+        if list.is_secondary {
+            self.free_secondary.push(buf);
+        } else {
+            self.free_primary.push(buf);
+        }
+        list.fence
+    }
+
+    /// Reset a specific command queue for reuse.
+    pub fn reset(&self, queue: &CommandQueue) -> Result<()> {
+        self.assert_owner();
+        unsafe {
+            (*self.ctx)
+                .device
+                .reset_command_buffer(queue.cmd_buf, vk::CommandBufferResetFlags::empty())?;
+        }
+        Ok(())
+    }
+
+    /// Destroy the underlying Vulkan command pool. Command buffers allocated
+    /// from this pool become invalid after this call.
+    pub fn destroy(&mut self) {
+        self.assert_owner();
+        unsafe {
+            (*self.ctx).device.destroy_command_pool(self.raw, None);
+        }
+        self.raw = vk::CommandPool::null();
+        self.free_primary.clear();
+        self.free_secondary.clear();
+    }
+}

--- a/src/gpu/vulkan/commands.rs
+++ b/src/gpu/vulkan/commands.rs
@@ -8,7 +8,8 @@ use crate::driver::state::vulkan::{USAGE_TO_ACCESS, USAGE_TO_STAGE};
 use crate::driver::state::{Layout, LayoutTransition};
 use crate::utils::Handle;
 use crate::{
-    BarrierPoint, BindGroup, BindTable, Buffer, ClearValue, CommandQueue, ComputePipeline, Context, DynamicBuffer, Fence, Filter, GPUError, GraphicsPipeline, IndexedBindGroup, IndexedIndirectCommand, IndirectCommand, QueueType, Rect2D, Result, Semaphore, SubmitInfo, SubmitInfo2, UsageBits, Viewport
+    ClearValue, CommandQueue, ComputePipeline, Context, Fence, GPUError, GraphicsPipeline, QueueType, Result, Semaphore,
+    SubmitInfo2, UsageBits,
 };
 
 // --- New: helpers to map engine Layout/UsageBits to Vulkan ---
@@ -100,9 +101,7 @@ impl CommandQueue {
     /// - Transitions must be handled via appropriate barriers.
     pub fn reset(&mut self) -> Result<()> {
         unsafe {
-            (*self.ctx)
-                .device
-                .reset_command_buffer(self.cmd_buf, vk::CommandBufferResetFlags::empty())?;
+            (*self.pool).reset(self)?;
 
             (*self.ctx).device.begin_command_buffer(
                 self.cmd_buf,
@@ -114,6 +113,14 @@ impl CommandQueue {
         self.curr_rp = None;
         self.curr_pipeline = None;
         Ok(())
+    }
+
+    /// Begin recording a secondary command queue using the same pool.
+    ///
+    /// The returned queue is a secondary command buffer that can be recorded
+    /// independently and later executed by this primary queue.
+    pub fn begin_secondary(&mut self, debug_name: &str) -> Result<CommandQueue> {
+        unsafe { (*self.pool).begin(debug_name, true) }
     }
     pub fn submit(
         &mut self,


### PR DESCRIPTION
## Summary
- track `Context` in `CommandPool` to allocate and recycle buffers per queue type
- spawn secondary command queues directly from their parent pool
- build Vulkan pools inside `Context::new`/`headless` and return boxed contexts for stable references

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c7743457d0832aa3e4fb16379f84cf