### PR TITLE
Add pluggable job executor with optional rayon support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ use_16_bit_node_indices = []
 vulkan = ["dep:ash", "dep:vk-mem", "dep:ash-window"]
 dx12 = ["dep:windows"]
 metal = ["dep:metal"]
+rayon = ["dep:rayon"]
 
 [dependencies]
 ash = { version = "0.37", optional = true }
@@ -33,7 +34,7 @@ metal = { version = "0.32.0", optional = true }
 bitflags = "2.6"
 bytemuck = { version = "1.16", features = ["derive"] }
 smallvec = "1.13"
-rayon = "1.10"
+rayon = { version = "1.10", optional = true }
 
 [patch.crates-io]
 orbclient = { path = "orbclient_stub" }

--- a/src/job/executor.rs
+++ b/src/job/executor.rs
@@ -1,0 +1,41 @@
+pub trait Executor {
+    fn run_boxed(&self, f: Box<dyn FnOnce() + Send + 'static>);
+    fn run<F: FnOnce() + Send + 'static>(&self, f: F)
+    where
+        Self: Sized,
+    {
+        self.run_boxed(Box::new(f));
+    }
+}
+
+#[derive(Default)]
+pub struct BasicExecutor;
+
+impl Executor for BasicExecutor {
+    fn run_boxed(&self, f: Box<dyn FnOnce() + Send + 'static>) {
+        std::thread::spawn(f);
+    }
+}
+
+#[cfg(feature = "rayon")]
+pub struct RayonExecutor {
+    pool: rayon::ThreadPool,
+}
+
+#[cfg(feature = "rayon")]
+impl RayonExecutor {
+    pub fn new(num_threads: usize) -> Self {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .build()
+            .expect("failed to build thread pool");
+        Self { pool }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl Executor for RayonExecutor {
+    fn run_boxed(&self, f: Box<dyn FnOnce() + Send + 'static>) {
+        self.pool.spawn(f);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Executor` trait with basic and Rayon-backed implementations
- allow `JobDispatch` to accept a boxed executor
- gate Rayon executor behind new `rayon` cargo feature

## Testing
- `cargo check`
- `cargo test`
- `cargo check --features rayon`


------
https://chatgpt.com/codex/tasks/task_e_68c79e079edc832aa2d88d19eb7d22f5