### PR TITLE
Add ThreadCtx for per-thread GPU command management

### DIFF
--- a/src/gpu/vulkan/mod.rs
+++ b/src/gpu/vulkan/mod.rs
@@ -50,7 +50,7 @@ mod pipelines;
 pub use pipelines::*;
 
 mod command_pool;
-use command_pool::CommandPool;
+pub use command_pool::CommandPool;
 
 
 /// Names of debugging layers that should be enabled when validation is requested.

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -1,9 +1,7 @@
 mod executor;
 pub use executor::*;
-
-/// Context provided to jobs running on worker threads.
-#[derive(Default)]
-pub struct ThreadCtx;
+mod thread_ctx;
+pub use thread_ctx::*;
 
 /// A job to be executed by the dispatcher.
 pub type Job = Box<dyn FnOnce(&mut ThreadCtx) + Send + 'static>;

--- a/src/job/thread_ctx.rs
+++ b/src/job/thread_ctx.rs
@@ -1,0 +1,72 @@
+use std::thread::ThreadId;
+
+use crate::gpu::vulkan::{CommandPool, CommandQueue, Context};
+use crate::Result;
+
+/// Per-thread context for job execution.
+///
+/// Holds a Vulkan command pool and reusable scratch allocations owned by the
+/// thread that created it. The context can be used by jobs to acquire
+/// secondary command buffers which are safe to reset and recycle.
+pub struct ThreadCtx {
+    /// Command pool used to allocate command buffers.
+    pool: Option<CommandPool>,
+    /// Identifier of the owning thread.
+    thread: ThreadId,
+    /// Scratch allocations that can be reused between jobs.
+    scratch: Vec<Vec<u8>>,
+}
+
+impl ThreadCtx {
+    /// Create a new thread context with the provided command pool.
+    pub fn new(pool: CommandPool) -> Self {
+        Self {
+            pool: Some(pool),
+            thread: std::thread::current().id(),
+            scratch: Vec::new(),
+        }
+    }
+
+    fn assert_owner(&self) {
+        debug_assert_eq!(
+            self.thread,
+            std::thread::current().id(),
+            "ThreadCtx used from wrong thread",
+        );
+    }
+
+    /// Acquire a secondary command buffer from the internal pool.
+    pub fn acquire_secondary(
+        &mut self,
+        ctx: *mut Context,
+        debug_name: &str,
+    ) -> Result<CommandQueue> {
+        self.assert_owner();
+        self
+            .pool
+            .as_mut()
+            .expect("CommandPool not initialized")
+            .begin(ctx, debug_name, true)
+    }
+
+    /// Reset a previously acquired command queue for reuse.
+    pub fn reset(&mut self, queue: &mut CommandQueue) -> Result<()> {
+        self.assert_owner();
+        self
+            .pool
+            .as_mut()
+            .expect("CommandPool not initialized")
+            .reset(queue)
+    }
+}
+
+impl Default for ThreadCtx {
+    fn default() -> Self {
+        Self {
+            pool: None,
+            thread: std::thread::current().id(),
+            scratch: Vec::new(),
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose Vulkan CommandPool type
- add ThreadCtx with per-thread CommandPool and scratch space
- allow acquiring and resetting secondary command buffers via ThreadCtx

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c79f9ad6f0832ab475892c1764702c