### PR TITLE
Add per-frame context ring allocator

### DIFF
--- a/src/job/frame_ctx.rs
+++ b/src/job/frame_ctx.rs
@@ -1,0 +1,115 @@
+use std::ptr::NonNull;
+
+use crate::{
+    gpu::vulkan::{CommandQueue, Context, QueueType},
+    utils::Handle,
+    Fence,
+    Result,
+};
+
+use super::{Job, ThreadCtx};
+
+/// Per-frame context holding jobs and GPU resources.
+pub struct FrameCtx {
+    /// Jobs queued for execution on this frame.
+    pub jobs: Vec<Job>,
+    /// Primary command buffer for this frame.
+    pub primary: CommandQueue,
+    /// Timeline value associated with the submitted work.
+    pub timeline: u64,
+    /// Completed thread contexts awaiting reset.
+    pub completed: Vec<ThreadCtx>,
+    /// Fence signaled when GPU work for this frame completes.
+    pub fence: Option<Handle<Fence>>,
+}
+
+impl FrameCtx {
+    /// Create an empty frame context.
+    pub fn new() -> Self {
+        Self {
+            jobs: Vec::new(),
+            primary: CommandQueue::default(),
+            timeline: 0,
+            completed: Vec::new(),
+            fence: None,
+        }
+    }
+
+    /// Record a finished thread context for later recycling.
+    pub fn push_completed(&mut self, ctx: ThreadCtx) {
+        self.completed.push(ctx);
+    }
+}
+
+/// Ring allocator for `FrameCtx` instances.
+pub struct FrameRing {
+    frames: Vec<FrameCtx>,
+    curr: usize,
+    ctx: NonNull<Context>,
+}
+
+impl FrameRing {
+    /// Create a new ring with the requested number of frames.
+    pub fn new(
+        ctx: &mut Context,
+        frame_count: usize,
+        queue_type: QueueType,
+        debug_name: &str,
+    ) -> Result<Self> {
+        let mut frames = Vec::new();
+        let raw_ctx = ctx as *mut Context;
+        let ctx_ptr = NonNull::new(raw_ctx).unwrap();
+        for i in 0..frame_count {
+            let primary = ctx
+                .pool_mut(queue_type)
+                .begin(raw_ctx, &format!("{debug_name}.{i}"), false)?;
+            frames.push(FrameCtx {
+                jobs: Vec::new(),
+                primary,
+                timeline: 0,
+                completed: Vec::new(),
+                fence: None,
+            });
+        }
+        Ok(Self {
+            frames,
+            curr: 0,
+            ctx: ctx_ptr,
+        })
+    }
+
+    /// Acquire the next frame, resetting resources once GPU work has completed.
+    pub fn acquire(&mut self, timeline: u64) -> Result<&mut FrameCtx> {
+        let idx = self.curr;
+        let len = self.frames.len();
+        let frame = &mut self.frames[idx];
+
+        if let Some(fence) = frame.fence.take() {
+            unsafe {
+                self.ctx.as_mut().wait(fence)?;
+            }
+            frame.primary.reset()?;
+            frame.completed.clear();
+            frame.jobs.clear();
+        }
+
+        frame.timeline = timeline;
+        self.curr = (self.curr + 1) % len;
+        Ok(frame)
+    }
+}
+
+impl Drop for FrameRing {
+    fn drop(&mut self) {
+        unsafe {
+            let ctx = self.ctx.as_mut();
+            for mut frame in self.frames.drain(..) {
+                if let Some(fence) = frame.fence.take() {
+                    let _ = ctx.wait(fence);
+                }
+                ctx.destroy_cmd_queue(frame.primary);
+            }
+        }
+    }
+}
+

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -2,20 +2,11 @@ mod executor;
 pub use executor::*;
 mod thread_ctx;
 pub use thread_ctx::*;
+mod frame_ctx;
+pub use frame_ctx::*;
 
 /// A job to be executed by the dispatcher.
 pub type Job = Box<dyn FnOnce(&mut ThreadCtx) + Send + 'static>;
-
-/// Per-frame queue of jobs.
-pub struct FrameCtx {
-    jobs: Vec<Job>,
-}
-
-impl FrameCtx {
-    fn new() -> Self {
-        Self { jobs: Vec::new() }
-    }
-}
 
 /// Statistics about dispatched jobs.
 #[derive(Default)]


### PR DESCRIPTION
## Summary
- Introduce `FrameCtx` to track per-frame command buffers, timeline values, and completed thread contexts
- Add `FrameRing` allocator that waits on fences before recycling frame resources
- Update job module to export the new frame context

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c7a15a54e4832a9f1da85f2062fbde